### PR TITLE
Rebuild OpenCV 4.5.5 against openblas 0.3.20 using new compilers

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,7 @@
 # This needs to be removed after the pinning of libprotobuf has been adjusted.
 libprotobuf:
 - 3.20
+libopenblas:
+- 0.3.20
+openblas_devel:
+- 0.3.20

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,9 @@
+c_compiler_version:        # [linux]
+  - 11.2.0                 # [linux]
+cxx_compiler_version:      # [linux]
+  - 11.2.0                 # [linux]
+fortran_compiler_version:  # [linux or osx]
+  - 11.2.0                 # [linux or osx]
 # This needs to be removed after the pinning of libprotobuf has been adjusted.
 libprotobuf:
 - 3.20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ build:
     - _openmp_mutex  # [linux]
     - python
     - libwebp-base # [win]
-    - libprotobuf  # [win]
     - gst-plugins-base # [win]
     - qt         # [win]
     - gstreamer  # [win]
@@ -112,7 +111,6 @@ outputs:
       ignore_run_exports:
         - openblas-devel # [x86_64 and not win]
         - libwebp-base # [win]
-        - libprotobuf  # [win]
         - gst-plugins-base # [win]
         - qt         # [win]
         - gstreamer  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.5.5" %}
-{% set build_num = "1" %}
+{% set build_num = "2" %}
 package:
   name: opencv-suite
   version: {{ version }}


### PR DESCRIPTION
Rebuild against OpenBLAS 0.3.20 using the new compilers, as well.