### PR TITLE
Headless

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,7 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,3 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,15 @@ if "%vc%" == "9" (
   copy "%LIBRARY_INC%\stdint.h" %SRC_DIR%\modules\highgui\include\stdint.h
 )
 
+if "%build_variant%" == "normal" (
+  echo "Building normal variant"
+  set QT_VERSION=5
+)
+else (
+  echo "Building headless variant"
+  set QT_VERSION=0
+)
+
 :: The following options are set in a way to make sure that the cmake files for
 :: both the main library and modules/functionality are detected correctly by
 :: downstreams... modify with caution:  OPENCV_CONFIG_INSTALL_PATH
@@ -88,7 +97,7 @@ cmake .. -LAH -G Ninja             ^
     -DWITH_OPENJPEG=0                               ^
     -DWITH_OPENNI=0                                 ^
     -DWITH_PROTOBUF=1                               ^
-    -DWITH_QT=5                                     ^
+    -DWITH_QT=%QT_VERSION%                          ^
     -DWITH_ZLIB=1 -DWITH_PNG=1 -DWITH_TIFF=1 -DWITH_TBB=0      ^
     -DWITH_TENGINE=0                                ^
     -DWITH_TESSERACT=0                              ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,8 +21,15 @@ echo "${PYTHON_CMAKE_ARGS[@]}"
 
 # Set defaults for dependencies that change across OSes
 # This should match the meta.yaml deps section
-VAR_DEPS=(EIGEN FFMPEG PROTOBUF GSTREAMER OPENJPEG OPENMP QT WEBP)
-DEPS_DEFAULTS=(1 0 0 1 1 1 5 0)
+if [[ "$build_variant" == "normal" ]]; then
+  echo "Building normal variant"
+  VAR_DEPS=(EIGEN FFMPEG PROTOBUF GSTREAMER OPENJPEG OPENMP QT WEBP)
+  DEPS_DEFAULTS=(1 0 0 1 1 1 5 0)
+else
+  echo "Building headless variant"
+  VAR_DEPS=(EIGEN FFMPEG PROTOBUF GSTREAMER OPENJPEG OPENMP WEBP)
+  DEPS_DEFAULTS=(1 0 0 1 1 1 0)
+fi
 if [[ ${#DEPS_DEFAULTS[@]} != ${#VAR_DEPS[@]} ]];then echo Setting defaults failed: Length mismatch;exit 1; fi
 for ii in ${!VAR_DEPS[@]};do
     eval "WITH_${VAR_DEPS[ii]}=${DEPS_DEFAULTS[ii]}"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
 build_variant:
-  - headless
-  # - normal
+  - normal
+  # As of 5/30/2022 headles is only to be available on the sfe1ed40 channel
+  # - headless

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+build_variant:
+  - headless
+  - normal

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 build_variant:
   - headless
-  - normal
+  # - normal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -188,7 +188,7 @@ outputs:
         - numpy
         - ninja
         - {{ cdt('libselinux-devel') }}      # [linux]
-        - {{ cdt('libx11-devel') }}          # [linux]
+        - {{ cdt('libx11-devel') }}          # [linux and build_variant == 'normal']
         - {{ cdt('libxau-devel') }}          # [linux]
         - {{ cdt('libxcb') }}                # [linux]
         - {{ cdt('libxdamage-devel') }}      # [linux]
@@ -199,7 +199,7 @@ outputs:
         - {{ cdt('libxxf86vm') }}            # [linux]
         - {{ cdt('mesa-dri-drivers') }}      # [linux]
         - {{ cdt('mesa-libgl-devel') }}      # [linux]
-        - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
+        - {{ cdt('xorg-x11-proto-devel') }}  # [linux and build_variant == 'normal']
       files:
         - test-cmake/CMakeLists.txt
         - test-cmake/DisplayImage.cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,16 @@
 {% set version = "4.6.0" %}
-{% set build_num = "3" %}
-
+{% set build_num = "4" %}
 
 {% if target_platform != "linux-aarch64" and target_platform != "linux-64"%}
 {%   set enable_testingui = true %}
 {% else %}
 {%   set enable_testingui = false %}
+{% endif %}
+
+{% if build_variant == "headless" %}
+{%   set package_name = "opencv-python-headless" %}
+{% else %}
+{%   set package_name = "opencv" %}
 {% endif %}
 
 package:
@@ -64,9 +69,9 @@ requirements:
     - libwebp-base 1.2.0       # [win or (linux and x86_64)]
     - numpy {{ numpy }}
     - python
-    - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le))]
-    - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le))]
-    - qtwebkit =5               # [not (linux and (s390x or ppc64le))]
+    - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+    - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+    - qtwebkit =5               # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
     - zlib 1.2.13
   run:
     - _openmp_mutex         # [linux]
@@ -91,13 +96,13 @@ requirements:
     - libwebp-base          # [win or (linux and x86_64)]
     - numpy >={{ numpy }},<2
     - python
-    - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le))]
-    - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le))]
-    - qtwebkit =5               # [not (linux and (s390x or ppc64le))]
+    - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+    - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+    - qtwebkit =5               # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
     - zlib >=1.2.13,<1.3.0a0
 
 outputs:
-  - name: opencv
+  - name: {{ package_name }}
     script: install.sh                           # [not win]
     script: install.bat                          # [win]
     build:
@@ -110,7 +115,8 @@ outputs:
       #
       #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
       #
-      - {{ pin_subpackage('opencv', max_pin='x.x') }}
+      - {{ pin_subpackage('opencv', max_pin='x.x') }} # [build_variant == 'normal']
+      - {{ pin_subpackage('opencv-python-headless', max_pin='x.x') }} # [build_variant == 'headless']
     requirements:
       build:
         - {{ compiler('c') }}
@@ -144,9 +150,9 @@ outputs:
         - libwebp-base 1.2.0    # [win or (linux and x86_64)]
         - numpy {{ numpy }}
         - python
-        - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le))]
-        - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le))]
-        - qtwebkit =5               # [not (linux and (s390x or ppc64le))]
+        - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+        - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+        - qtwebkit =5               # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
         - zlib 1.2.13
       run:
         - _openmp_mutex         # [linux]
@@ -170,9 +176,9 @@ outputs:
         - libwebp-base          # [win or (linux and x86_64)]
         - numpy >={{ numpy }},<2
         - python
-        - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le))]
-        - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le))]
-        - qtwebkit =5               # [not (linux and (s390x or ppc64le))]
+        - qt-main >=5.15,<6         # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+        - qt-webengine >=5.15.7,<6  # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
+        - qtwebkit =5               # [not (linux and (s390x or ppc64le)) and build_variant == 'normal']
         - zlib >=1.2.13,<1.3.0a0
     test:
       requires:
@@ -252,6 +258,7 @@ outputs:
         - if not exist %CONDA_PREFIX%\\Library\\bin\\opencv_{{ each_opencv_lib }}{{ version|replace(".","") }}.dll exit 1 # [win]
         {% endfor %}
 
+  {% if build_variant == "normal" %}
   # This recipe has merged the outputs for the compiled libraries with the
   # python bindings that used to be vendored as libopencv and py-opencv. This
   # was done to try to improve maintainibility. The following two output
@@ -276,10 +283,9 @@ outputs:
       - {{ pin_subpackage('libopencv', max_pin='x.x') }}
     requirements:
       host:
-        - opencv =={{ version }}
+        - {{ package_name }} =={{ version }}
       run:
-        - opencv =={{ version }}
-
+        - {{ package_name }} =={{ version }}
 
   - name: py-opencv
     script: install-nothing.sh                  # [not win]
@@ -291,9 +297,10 @@ outputs:
         - "*"   # [osx]
     requirements:
       host:
-        - opencv =={{ version }}
+        - {{ package_name }} =={{ version }}
       run:
-        - opencv =={{ version }}
+        - {{ package_name }} =={{ version }}
+  {% endif %}
 
 about:
   home: https://opencv.org/


### PR DESCRIPTION
Jira: https://anaconda.atlassian.net/browse/PKG-2049

## Changes
- Bump build number
- Add two build `build_variant`
    - `normal`
        - Outputs `opencv`, `libopencv` and `py-opencv` as before
    - `headless`
        - Outputs just `opencv-python-headless`, the `opencv` without GUI components (QT, X11..)