### PR TITLE
opencv 4.10.0: Rebuild against hdf5 1.14.5 & ffmpeg 6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,7 +112,7 @@ outputs:
         - gst-plugins-base 1.22.3 # [win]
         - gstreamer 1.22.3 # [win]
         - hdf5 {{ hdf5 }}
-        - jpeg {{ jpeg }}           # [not win]
+        - jpeg {{ jpeg }}
         - openjpeg {{ openjpeg }}
         - libiconv 1.16             # [unix]
         - libpng  {{ libpng }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.10.0" %}
-{% set build_num = "0" %}
+{% set build_num = "1" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
@@ -77,7 +77,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        - {{ compiler('cxx') }}    
+        - {{ compiler('cxx') }}
         - pkg-config
         - cmake
         - ninja-base
@@ -102,7 +102,7 @@ outputs:
         - python
         - numpy {{ numpy }}
         - eigen 3.4.0
-        - ffmpeg 4                  # [not win]
+        - ffmpeg 6                  # [not win]
         - freetype {{ freetype }}
         # harfbuzz, glib, gettext are both needed for freetype support
         - harfbuzz {{ harfbuzz }}
@@ -118,7 +118,7 @@ outputs:
         - libpng  {{ libpng }}
         - libprotobuf 4.25.3
         - libabseil 20240116.2
-        - libtiff 4.5
+        - libtiff {{ libtiff }}
         - libwebp-base {{ libwebp }}
         - qt-main 5                 # [build_variant == "normal"]
         - zlib {{ zlib }}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6130](https://anaconda.atlassian.net/browse/PKG-6130) 
- [Upstream repository](https://github.com/opencv/opencv/tree/4.10.0)
- Requirements:
  - https://github.com/opencv/opencv/blob/4.10.0/CMakeLists.txt
  - https://github.com/opencv/opencv/blob/4.10.0/modules/python/package/setup.py
  - https://github.com/opencv/opencv-python/blob/master/README.md#frequently-asked-questions
  - configs https://github.com/opencv/opencv/blob/4.10.0/doc/tutorials/introduction/config_reference/config_reference.markdown#png-jpeg-tiff-webp-support
  - Windows https://github.com/opencv/opencv/blob/4.10.0/doc/tutorials/introduction/windows_install/windows_install.markdown

### Explanation of changes:

- Bump the build number to `1`.
- Add support for building `py313` artifacts
- Update host pinnings: `ffmpeg 6`, `libtiff {{ libtiff }}`
- Enable `jpeg` on `win` in `host`

### Notes:

- Rebuild against `hdf5 1.14.5` & `ffmpeg 6`

[PKG-6130]: https://anaconda.atlassian.net/browse/PKG-6130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ