### PR TITLE
opencv 4.10.0: Rebuild against harfbuzz 10.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/harfbuzz-feedstock/pr20/62acfe5
-  - https://staging.continuum.io/prefect/fs/pango-feedstock/pr2/06cea1b
-  - https://staging.continuum.io/prefect/fs/librsvg-feedstock/pr10/fedf992
-  - https://staging.continuum.io/prefect/fs/ffmpeg-feedstock/pr9/a36d6df

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/harfbuzz-feedstock/pr20/62acfe5

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,6 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/harfbuzz-feedstock/pr20/62acfe5
+  - https://staging.continuum.io/prefect/fs/pango-feedstock/pr2/06cea1b
+  - https://staging.continuum.io/prefect/fs/librsvg-feedstock/pr10/fedf992
+  - https://staging.continuum.io/prefect/fs/ffmpeg-feedstock/pr9/a36d6df

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,5 +2,6 @@ build_variant:
   - normal
   # As of 5/30/2022 headles is only to be available on the sfe1ed40 channel
   # - headless
+
 harfbuzz:
   - 10

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,5 @@ build_variant:
   - normal
   # As of 5/30/2022 headles is only to be available on the sfe1ed40 channel
   # - headless
+harfbuzz:
+  - 10

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.10.0" %}
-{% set build_num = "1" %}
+{% set build_num = "2" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6987](https://anaconda.atlassian.net/browse/PKG-6987) 
- [Upstream repository]()

### Explanation of changes:

- Bump build number to 2
- Add a local cbc.yaml with harfbuzz 10


### Notes:

-

[PKG-6987]: https://anaconda.atlassian.net/browse/PKG-6987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ