### PR TITLE
Rebuild with Qt 6.7.2

### DIFF
--- a/recipe/build_opencv.bat
+++ b/recipe/build_opencv.bat
@@ -3,7 +3,7 @@ setlocal enabledelayedexpansion
 
 if "%build_variant%" == "normal" (
   echo "Building normal variant"
-  set QT_VERSION=5
+  set QT_VERSION=6
 ) else (
   echo "Building headless variant"
   set QT_VERSION=0

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -16,7 +16,7 @@ fi
 
 if [[ "$build_variant" == "normal" ]]; then
     echo "Building normal variant"
-    QT="5"
+    QT="6"
 else
     echo "Building headless variant"
     QT="0"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 build_variant:
   - normal
-  # As of 5/30/2022 headles is only to be available on the sfe1ed40 channel
+  # As of 5/30/2022 headless is only to be available on the sfe1ed40 channel
   # - headless
 
 harfbuzz:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.10.0" %}
-{% set build_num = "2" %}
+{% set build_num = "3" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
@@ -65,6 +65,9 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_num }}
+      ignore_run_exports:
+        # qt5compat is needed for a CMake find_package() call but is not actually used in OpenCV anymore.
+        - qt5compat
     run_exports:
       # We are cautiously optimistic here that patch-level updates won't break
       # ABI. However, it sounds like upstream won't guarantee *any* sort of
@@ -82,21 +85,20 @@ outputs:
         - cmake
         - ninja-base
         # pkg-config on win pulls in python
-        # adding here explicitely to pull in the same version as in host
+        # adding here explicitly to pull in the same version as in host
         - python                         # [win]
         - {{ cdt('libselinux') }}        # [linux]
         - {{ cdt('libxau-devel') }}      # [linux]
         - {{ cdt('libxcb') }}            # [linux]
-        - {{ cdt('libxdamage') }}        # [linux]
         - {{ cdt('libxdamage-devel') }}  # [linux]
         - {{ cdt('libxext-devel') }}     # [linux]
-        - {{ cdt('libxfixes') }}         # [linux]
         - {{ cdt('libxfixes-devel') }}   # [linux]
         - {{ cdt('libxi-devel') }}       # [linux]
         - {{ cdt('libxrender-devel') }}  # [linux]
         - {{ cdt('libxxf86vm') }}        # [linux]
-        - {{ cdt('mesa-libgl-devel') }}  # [linux]
         - {{ cdt('mesa-libegl-devel') }} # [linux]
+        - {{ cdt('mesa-libgbm') }}       # [linux]
+        - {{ cdt('mesa-libgl-devel') }}  # [linux]
         - {{ cdt('mesa-dri-drivers') }}  # [linux]
       host:
         - python
@@ -120,7 +122,8 @@ outputs:
         - libabseil 20240116.2
         - libtiff {{ libtiff }}
         - libwebp-base {{ libwebp }}
-        - qt-main 5                 # [build_variant == "normal"]
+        - qtbase 6                 # [build_variant == "normal"]
+        - qt5compat                # [build_variant == "normal"]
         - zlib {{ zlib }}
       run:
         - _openmp_mutex         # [linux]
@@ -143,111 +146,122 @@ outputs:
         - libabseil
         - libtiff
         - libwebp-base
-        - qt-main         # [build_variant == "normal"]
+        - qtbase          # [build_variant == "normal"]
         - zlib
 
     test:
-        imports:
-          - cv2
-          - cv2.xfeatures2d
-          - cv2.freetype
         source_files:
           - test.avi
         requires:
           - {{ compiler('c') }}
           - {{ compiler('cxx') }}
-          - pkg-config                    # [not win]
+          - pkg-config                     # [not win]
           - cmake
           - ninja
           - pip
+          - {{ cdt('mesa-libgl') }}        # [linux]
+          - {{ cdt('libx11') }}            # [linux]
+          - {{ cdt('libxau') }}            # [linux]
+          - {{ cdt('libxext') }}           # [linux]
+          - {{ cdt('libxdamage') }}        # [linux]
+          - {{ cdt('libxfixes') }}         # [linux]
+          - {{ cdt('libxxf86vm') }}        # [linux]
+          - {{ cdt('mesa-dri-drivers') }}  # [linux]
+          - {{ cdt('mesa-libegl') }}       # [linux]
+          - {{ cdt('mesa-libgbm') }}       # [linux]
         files:
           - CMakeLists.txt
           - test.cpp
+          - run_import_test.py
           - run_py_test.py
           - color_palette_alpha.png
           - test_1_c1.jpg
         commands:
-            # Verify dynamic libraries on all systems
-            {% set win_ver_lib = version|replace(".", "") %}
-            # The bot doesn't support multiline jinja, so use
-            # single line jinja.
-            {% set opencv_libs = [] %}
-            {{ opencv_libs.append("alphamat") or "" }}
-            {{ opencv_libs.append("aruco") or "" }}
-            {{ opencv_libs.append("bgsegm") or "" }}
-            {{ opencv_libs.append("calib3d") or "" }}
-            {{ opencv_libs.append("ccalib") or "" }}
-            {{ opencv_libs.append("core") or "" }}
-            {{ opencv_libs.append("datasets") or "" }}
-            {{ opencv_libs.append("dnn_objdetect") or "" }}
-            {{ opencv_libs.append("dnn_superres") or "" }}
-            {{ opencv_libs.append("dnn") or "" }}
-            {{ opencv_libs.append("dpm") or "" }}
-            {{ opencv_libs.append("face") or "" }}
-            {{ opencv_libs.append("features2d") or "" }}
-            {{ opencv_libs.append("flann") or "" }}
-            {{ opencv_libs.append("fuzzy") or "" }}
-            {{ opencv_libs.append("gapi") or "" }}
-            {{ opencv_libs.append("hfs") or "" }}
-            {{ opencv_libs.append("highgui") or "" }}
-            {{ opencv_libs.append("img_hash") or "" }}
-            {{ opencv_libs.append("imgcodecs") or "" }}
-            {{ opencv_libs.append("imgproc") or "" }}
-            {{ opencv_libs.append("intensity_transform") or "" }}
-            {{ opencv_libs.append("line_descriptor") or "" }}
-            {{ opencv_libs.append("mcc") or "" }}
-            {{ opencv_libs.append("ml") or "" }}
-            {{ opencv_libs.append("objdetect") or "" }}
-            {{ opencv_libs.append("optflow") or "" }}
-            {{ opencv_libs.append("phase_unwrapping") or "" }}
-            {{ opencv_libs.append("photo") or "" }}
-            {{ opencv_libs.append("plot") or "" }}
-            {{ opencv_libs.append("quality") or "" }}
-            {{ opencv_libs.append("rapid") or "" }}
-            {{ opencv_libs.append("reg") or "" }}
-            {{ opencv_libs.append("rgbd") or "" }}
-            {{ opencv_libs.append("saliency") or "" }}
-            {{ opencv_libs.append("shape") or "" }}
-            {{ opencv_libs.append("stereo") or "" }}
-            {{ opencv_libs.append("stitching") or "" }}
-            {{ opencv_libs.append("structured_light") or "" }}
-            {{ opencv_libs.append("superres") or "" }}
-            {{ opencv_libs.append("surface_matching") or "" }}
-            {{ opencv_libs.append("text") or "" }}
-            {{ opencv_libs.append("tracking") or "" }}
-            {{ opencv_libs.append("video") or "" }}
-            {{ opencv_libs.append("videoio") or "" }}
-            {{ opencv_libs.append("videostab") or "" }}
-            {{ opencv_libs.append("wechat_qrcode") or "" }}
-            {{ opencv_libs.append("xfeatures2d") or "" }}
-            {{ opencv_libs.append("ximgproc") or "" }}
-            {{ opencv_libs.append("xobjdetect") or "" }}
-            {{ opencv_libs.append("xphoto") or "" }}
-            {{ opencv_libs.append("freetype") or "" }}
-            - export MACOSX_DEPLOYMENT_TARGET={{ MACOSX_DEPLOYMENT_TARGET }}      # [osx]
-            - export CONDA_BUILD_SYSROOT={{ CONDA_BUILD_SYSROOT }}                # [osx]
-            - OPENCV_FLAGS=`pkg-config --cflags opencv4`                          # [unix]
-            - $CXX -std=c++11 test.cpp ${OPENCV_FLAGS} -o test        # [unix]
-            - if [[ $(./test) != $PKG_VERSION ]]; then exit 1 ; fi                # [unix]
-            {% for each_opencv_lib in opencv_libs %}
-            - echo Testing for presence of {{ each_opencv_lib }}
-            - test -f $PREFIX/lib/libopencv_{{ each_opencv_lib }}${SHLIB_EXT}     # [unix]
-            - if not exist %PREFIX%\\Library\\bin\\opencv_{{ each_opencv_lib }}{{ win_ver_lib }}.dll exit 1  # [win]
-            - echo Found                   {{ each_opencv_lib }}
-            {% endfor %}
-            - test -f $PREFIX/lib/libopencv_bioinspired${SHLIB_EXT}  # [unix]
-            - test -f $PREFIX/lib/libopencv_hdf${SHLIB_EXT}          # [unix]
-            - mkdir -p cmake_build_test && pushd cmake_build_test
-            - cmake -G "Ninja" ..
-            - cmake --build . --config Release
-            - popd
-            - python run_py_test.py
-            - if [[ $(python -c 'import cv2; print(cv2.__version__)') != $PKG_VERSION ]]; then exit 1; fi  # [unix]
-            - python -c "import cv2; assert 'Unknown' not in cv2.videoio_registry.getBackendName(cv2.CAP_V4L)"  # [linux]
-            - pip check
-            - pip list
-            - test $(pip list | grep opencv-python | wc -l) -eq 2  # [unix]
-            - test $(pip list | grep opencv-python-headless | wc -l) -eq 1  # [unix]
+          # Verify dynamic libraries on all systems
+          {% set win_ver_lib = version|replace(".", "") %}
+          # The bot doesn't support multiline jinja, so use
+          # single line jinja.
+          {% set opencv_libs = [] %}
+          {{ opencv_libs.append("alphamat") or "" }}
+          {{ opencv_libs.append("aruco") or "" }}
+          {{ opencv_libs.append("bgsegm") or "" }}
+          {{ opencv_libs.append("calib3d") or "" }}
+          {{ opencv_libs.append("ccalib") or "" }}
+          {{ opencv_libs.append("core") or "" }}
+          {{ opencv_libs.append("datasets") or "" }}
+          {{ opencv_libs.append("dnn_objdetect") or "" }}
+          {{ opencv_libs.append("dnn_superres") or "" }}
+          {{ opencv_libs.append("dnn") or "" }}
+          {{ opencv_libs.append("dpm") or "" }}
+          {{ opencv_libs.append("face") or "" }}
+          {{ opencv_libs.append("features2d") or "" }}
+          {{ opencv_libs.append("flann") or "" }}
+          {{ opencv_libs.append("fuzzy") or "" }}
+          {{ opencv_libs.append("gapi") or "" }}
+          {{ opencv_libs.append("hfs") or "" }}
+          {{ opencv_libs.append("highgui") or "" }}
+          {{ opencv_libs.append("img_hash") or "" }}
+          {{ opencv_libs.append("imgcodecs") or "" }}
+          {{ opencv_libs.append("imgproc") or "" }}
+          {{ opencv_libs.append("intensity_transform") or "" }}
+          {{ opencv_libs.append("line_descriptor") or "" }}
+          {{ opencv_libs.append("mcc") or "" }}
+          {{ opencv_libs.append("ml") or "" }}
+          {{ opencv_libs.append("objdetect") or "" }}
+          {{ opencv_libs.append("optflow") or "" }}
+          {{ opencv_libs.append("phase_unwrapping") or "" }}
+          {{ opencv_libs.append("photo") or "" }}
+          {{ opencv_libs.append("plot") or "" }}
+          {{ opencv_libs.append("quality") or "" }}
+          {{ opencv_libs.append("rapid") or "" }}
+          {{ opencv_libs.append("reg") or "" }}
+          {{ opencv_libs.append("rgbd") or "" }}
+          {{ opencv_libs.append("saliency") or "" }}
+          {{ opencv_libs.append("shape") or "" }}
+          {{ opencv_libs.append("stereo") or "" }}
+          {{ opencv_libs.append("stitching") or "" }}
+          {{ opencv_libs.append("structured_light") or "" }}
+          {{ opencv_libs.append("superres") or "" }}
+          {{ opencv_libs.append("surface_matching") or "" }}
+          {{ opencv_libs.append("text") or "" }}
+          {{ opencv_libs.append("tracking") or "" }}
+          {{ opencv_libs.append("video") or "" }}
+          {{ opencv_libs.append("videoio") or "" }}
+          {{ opencv_libs.append("videostab") or "" }}
+          {{ opencv_libs.append("wechat_qrcode") or "" }}
+          {{ opencv_libs.append("xfeatures2d") or "" }}
+          {{ opencv_libs.append("ximgproc") or "" }}
+          {{ opencv_libs.append("xobjdetect") or "" }}
+          {{ opencv_libs.append("xphoto") or "" }}
+          {{ opencv_libs.append("freetype") or "" }}
+          # Add runtime path of libEGL.so.1 so ocv libraries can find it as they're loaded in.
+          # This must be done before the python interpreter starts up.
+          - export LD_LIBRARY_PATH="${PREFIX}/${BUILD/conda_cos7/conda}/sysroot/usr/lib64:${LD_LIBRARY_PATH}"  # [linux]
+          - python run_import_test.py
+          - export MACOSX_DEPLOYMENT_TARGET={{ MACOSX_DEPLOYMENT_TARGET }}      # [osx]
+          - export CONDA_BUILD_SYSROOT={{ CONDA_BUILD_SYSROOT }}                # [osx]
+          - OPENCV_FLAGS=`pkg-config --cflags opencv4`                          # [unix]
+          - $CXX -std=c++11 test.cpp ${OPENCV_FLAGS} -o test                    # [unix]
+          - if [[ $(./test) != $PKG_VERSION ]]; then exit 1 ; fi                # [unix]
+          {% for each_opencv_lib in opencv_libs %}
+          - echo Testing for presence of {{ each_opencv_lib }}
+          - test -f $PREFIX/lib/libopencv_{{ each_opencv_lib }}${SHLIB_EXT}     # [unix]
+          - if not exist %PREFIX%\\Library\\bin\\opencv_{{ each_opencv_lib }}{{ win_ver_lib }}.dll exit 1  # [win]
+          - echo Found                   {{ each_opencv_lib }}
+          {% endfor %}
+          - test -f $PREFIX/lib/libopencv_bioinspired${SHLIB_EXT}  # [unix]
+          - test -f $PREFIX/lib/libopencv_hdf${SHLIB_EXT}          # [unix]
+          - mkdir -p cmake_build_test && pushd cmake_build_test
+          - cmake -G "Ninja" ..
+          - cmake --build . --config Release
+          - popd
+          - python run_py_test.py
+          - if [[ $(python -c 'import cv2; print(cv2.__version__)') != $PKG_VERSION ]]; then exit 1; fi  # [unix]
+          - python -c "import cv2; assert 'Unknown' not in cv2.videoio_registry.getBackendName(cv2.CAP_V4L)"  # [linux]
+          - pip check
+          - pip list
+          - test $(pip list | grep opencv-python | wc -l) -eq 2  # [unix]
+          - test $(pip list | grep opencv-python-headless | wc -l) -eq 1  # [unix]
 
   {% if build_variant == "normal" %}
   # This recipe has merged the outputs for the compiled libraries with the
@@ -306,6 +320,8 @@ about:
   doc_url: https://docs.opencv.org/{{ major_version }}.x/
 
 extra:
+  skip-lints:
+    - host_section_needs_exact_pinnings
   recipe-maintainers:
     - h-vetinari
     - xhochy

--- a/recipe/run_import_test.py
+++ b/recipe/run_import_test.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python3
+
+print("import: 'cv2'")
+import cv2
+
+print("import: 'cv2.xfeatures2d'")
+import cv2.xfeatures2d
+
+print("import: 'cv2.freetype'")
+import cv2.freetype
+
+print("import: 'cv2'")
+import cv2
+
+print("import: 'cv2.freetype'")
+import cv2.freetype
+
+print("import: 'cv2.xfeatures2d'")
+import cv2.xfeatures2d


### PR DESCRIPTION
opencv 4.10.0 b3

**Destination channel:** defaults

### Links

- [PKG-6384](https://anaconda.atlassian.net/browse/PKG-6384)
- [Upstream repository](https://github.com/opencv/opencv/tree/4.10.0)

### Explanation of changes:

- Updated formatting
- Use qtbase so overdepending checks work
- Move import tests into script to allow LD_LIBRARY_PATH setting before running


[PKG-6384]: https://anaconda.atlassian.net/browse/PKG-6384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ