### PR TITLE
opencv 4.10.0: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
-  - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8
-  - https://staging.continuum.io/prefect/fs/gdk-pixbuf-feedstock/pr6/ffce0d6

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,3 +6,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
   - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda
   - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8
+  - https://staging.continuum.io/prefect/fs/gdk-pixbuf-feedstock/pr6/ffce0d6

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
   - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
   - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,5 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/8ca27b2
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/8ca27b2

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,5 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/0896de1

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,4 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
   - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
+  - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,5 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/0896de1
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
+  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -115,7 +115,7 @@ outputs:
         - gstreamer 1.22.3 # [win]
         - hdf5 {{ hdf5 }}
         - jpeg {{ jpeg }}
-        - openjpeg {{ openjpeg }}
+        - openjpeg 2.5.2
         - libiconv 1.16             # [unix]
         - libpng  {{ libpng }}
         - libprotobuf 5.29.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.10.0" %}
-{% set build_num = "3" %}
+{% set build_num = "4" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
@@ -120,7 +120,7 @@ outputs:
         - libpng  {{ libpng }}
         - libprotobuf 4.25.3
         - libabseil 20240116.2
-        - libtiff {{ libtiff }}
+        - libtiff 4.7.0
         - libwebp-base {{ libwebp }}
         - qtbase 6                 # [build_variant == "normal"]
         - qt5compat                # [build_variant == "normal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.10.0" %}
-{% set build_num = "4" %}
+{% set build_num = "5" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,7 +120,7 @@ outputs:
         - libpng  {{ libpng }}
         - libprotobuf 5.29.3
         - libabseil 20250127.0
-        - libtiff 4.7.0
+        - libtiff {{ libtiff }}
         - libwebp-base {{ libwebp }}
         - qtbase 6                 # [build_variant == "normal"]
         - qt5compat                # [build_variant == "normal"]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7593](https://anaconda.atlassian.net/browse/PKG-7593) 
- [Upstream repository](https://github.com/opencv/opencv/tree/4.10.0)

### Explanation of changes:

- Bump the build number to 5
- Pin libtiff in host

### Notes:

-

[PKG-7593]: https://anaconda.atlassian.net/browse/PKG-7593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ