### PR TITLE
opencv 4.10.0: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/c308172
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
+channels:
+  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/19a927e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
   - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
   - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
   - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,6 @@ channels:
   - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
   - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c
   - https://staging.continuum.io/prefect/fs/qt5compat-feedstock/pr3/738f022
+
+extra_labels_for_os:
+  osx-arm64: [ventura]

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/c308172

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,7 +4,3 @@ channels:
   - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
   - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c
   - https://staging.continuum.io/prefect/fs/qt5compat-feedstock/pr3/738f022
-
-extra_labels_for_os:
-  # Ventura failed on Prefect occasionally.
-  osx-arm64: [big-sur]

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
-  - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c
-  - https://staging.continuum.io/prefect/fs/qt5compat-feedstock/pr3/738f022

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 channels:
   - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
+  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
+  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288
+  - https://staging.continuum.io/prefect/fs/qtdeclarative-feedstock/pr3/80cb92c
+  - https://staging.continuum.io/prefect/fs/qt5compat-feedstock/pr3/738f022

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,4 +6,5 @@ channels:
   - https://staging.continuum.io/prefect/fs/qt5compat-feedstock/pr3/738f022
 
 extra_labels_for_os:
-  osx-arm64: [ventura]
+  # Ventura failed on Prefect occasionally.
+  osx-arm64: [big-sur]

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/19a927e

--- a/recipe/build_opencv.bat
+++ b/recipe/build_opencv.bat
@@ -2,11 +2,9 @@
 setlocal enabledelayedexpansion
 
 if "%build_variant%" == "normal" (
-  echo "Building normal variant"
-  set QT_VERSION=6
+  echo "Building normal variant with Qt%QT%"
 ) else (
-  echo "Building headless variant"
-  set QT_VERSION=0
+  echo "Building headless variant without Qt"
 )
 
 for /F "tokens=1,2 delims=. " %%a in ("%PY_VER%") do (
@@ -111,7 +109,7 @@ cmake -LAH -G "Ninja"                                                           
     -DWITH_VA_INTEL=0                                                               ^
     -DWITH_VTK=0                                                                    ^
     -DWITH_GTK=0                                                                    ^
-    -DWITH_QT=%QT_VERSION%                                                          ^
+    -DWITH_QT=%QT%                                                          ^
     -DWITH_GPHOTO2=0                                                                ^
     -DWITH_WIN32UI=0                                                                ^
     -DINSTALL_C_EXAMPLES=0                                                          ^

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -35,9 +35,11 @@ fi
 
 export PKG_CONFIG_LIBDIR=$PREFIX/lib
 
-# Set up include paths for GLib and GStreamer
-export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
-export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
+# Set up include paths for GLib and GStreamer on macOS
+if [[ "${target_platform}" == osx-* ]]; then
+    export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
+    export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
+fi
 
 IS_PYPY=$(${PYTHON} -c "import platform; print(int(platform.python_implementation() == 'PyPy'))")
 

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -53,6 +53,21 @@ if ! pkg-config --exists gstreamer-1.0; then
     GSTREAMER_ENABLE=0
 fi
 
+# Workaround for missing GLib include directories that GStreamer expects
+if [[ ! -d "$PREFIX/include/glib-2.0" ]]; then
+    mkdir -p "$PREFIX/include/glib-2.0"
+    echo "// Dummy glib.h to prevent CMake errors" > "$PREFIX/include/glib-2.0/glib.h"
+fi
+
+if [[ ! -d "$PREFIX/lib/glib-2.0/include" ]]; then
+    mkdir -p "$PREFIX/lib/glib-2.0/include"
+    echo "// Dummy glibconfig.h to prevent CMake errors" > "$PREFIX/lib/glib-2.0/include/glibconfig.h"
+fi
+
+# Set up include paths for GLib and GStreamer
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
+
 mkdir -p build${PY_VER}
 cd build${PY_VER}
 

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -50,6 +50,19 @@ fi
 # FFMPEG building requires pkgconfig
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
 
+# Set up proper include paths for GLib and GStreamer
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
+
+# Ensure OpenGL libraries can be found for Qt
+if [[ "${target_platform}" == linux-* ]]; then
+    export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
+    # Make sure CMake can find OpenGL libraries
+    export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_gl_LIBRARY=$PREFIX/lib/libGL.so"
+    export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_glu_LIBRARY=$PREFIX/lib/libGLU.so"
+    export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_INCLUDE_DIR=$PREFIX/include/GL"
+fi
+
 mkdir -p build${PY_VER}
 cd build${PY_VER}
 
@@ -127,6 +140,7 @@ cmake -LAH -G "Ninja"                                                     \
     -DWITH_VTK=0                                                          \
     -DWITH_GTK=0                                                          \
     -DWITH_QT=$QT                                                         \
+    -DWITH_OPENGL=ON                                                      \
     -DWITH_GPHOTO2=0                                                      \
     -DINSTALL_C_EXAMPLES=0                                                \
     -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib/modules"               \

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -15,11 +15,9 @@ if [[ "${target_platform}" == linux-* ]]; then
 fi
 
 if [[ "$build_variant" == "normal" ]]; then
-    echo "Building normal variant with Qt6"
-    QT="6"
+    echo "Building normal variant with Qt${QT}"
 else
     echo "Building headless variant without Qt"
-    QT="0"
 fi
 
 if [[ "${target_platform}" == osx-* ]]; then
@@ -34,12 +32,6 @@ if [[ "${target_platform}" != "${build_platform}" ]]; then
 fi
 
 export PKG_CONFIG_LIBDIR=$PREFIX/lib
-
-# Set up include paths for GLib and GStreamer on macOS
-if [[ "${target_platform}" == osx-* ]]; then
-    export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
-    export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
-fi
 
 IS_PYPY=$(${PYTHON} -c "import platform; print(int(platform.python_implementation() == 'PyPy'))")
 

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -35,6 +35,10 @@ fi
 
 export PKG_CONFIG_LIBDIR=$PREFIX/lib
 
+# Set up include paths for GLib and GStreamer
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
+
 IS_PYPY=$(${PYTHON} -c "import platform; print(int(platform.python_implementation() == 'PyPy'))")
 
 LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER}${SHLIB_EXT}"

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 set -ex
 
-echo "=== OpenCV Build Script Debug Information ==="
-echo "Date: $(date)"
-echo "Build platform: ${build_platform:-unknown}"
-echo "Target platform: ${target_platform:-unknown}"
-echo "Build variant: ${build_variant:-unknown}"
-echo "Python version: ${PY_VER:-unknown}"
-echo "PREFIX: $PREFIX"
-echo "SP_DIR: $SP_DIR"
-echo "CPU_COUNT: ${CPU_COUNT:-unknown}"
-
 # CMake FindPNG seems to look in libpng not libpng16
 # https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindPNG.cmake#L55
 ln -s $PREFIX/include/libpng16 $PREFIX/include/libpng
@@ -22,7 +12,6 @@ if [[ "${target_platform}" == linux-* ]]; then
     # with GCC opencv/issues/8097
     export CXXFLAGS="$CXXFLAGS -D__STDC_CONSTANT_MACROS"
     OPENMP="-DWITH_OPENMP=1"
-    echo "Linux build detected - enabling OpenMP and adding STDC_CONSTANT_MACROS"
 fi
 
 if [[ "$build_variant" == "normal" ]]; then
@@ -31,28 +20,22 @@ if [[ "$build_variant" == "normal" ]]; then
 else
     echo "Building headless variant without Qt"
     QT="0"
-    echo $QT
 fi
 
 if [[ "${target_platform}" == osx-* ]]; then
     V4L="0"
-    echo "macOS build detected - disabling V4L"
 elif [[ "${target_platform}" == linux-ppc64le ]]; then
     OPENVINO="0"
-    echo "Linux PPC64LE build detected - disabling OpenVINO"
 fi
 
 if [[ "${target_platform}" != "${build_platform}" ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc"
     CMAKE_ARGS="${CMAKE_ARGS} -DQT_HOST_PATH=${BUILD_PREFIX}"
-    echo "Cross-compilation detected - setting protoc and Qt host paths"
 fi
 
 export PKG_CONFIG_LIBDIR=$PREFIX/lib
 
 IS_PYPY=$(${PYTHON} -c "import platform; print(int(platform.python_implementation() == 'PyPy'))")
-echo "Python implementation: $(${PYTHON} -c "import platform; print(platform.python_implementation())")"
-echo "Is PyPy: $IS_PYPY"
 
 LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER}${SHLIB_EXT}"
 if [[ ${IS_PYPY} == "1" ]]; then
@@ -61,166 +44,17 @@ else
     INC_PYTHON="$PREFIX/include/python${PY_VER}"
 fi
 
-echo "Python library: $LIB_PYTHON"
-echo "Python include: $INC_PYTHON"
-
 # FFMPEG building requires pkgconfig
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
-echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
-echo "PKG_CONFIG_LIBDIR: $PKG_CONFIG_LIBDIR"
 
-# Debug: Check critical dependencies
-echo "=== Debug: Checking critical dependencies ==="
-echo "Checking for essential libraries and headers..."
-for lib in libz libpng libjpeg libtiff libwebp libopenjpeg libprotobuf libhdf5; do
-    if [[ -f "$PREFIX/lib/${lib}.so" || -f "$PREFIX/lib/${lib}.dylib" || -f "$PREFIX/lib/${lib}.a" ]]; then
-        echo "✓ Found: $lib"
-    else
-        echo "✗ Missing: $lib"
-    fi
-done
-
-echo "Checking for Python NumPy..."
-${PYTHON} -c "import numpy; print(f'NumPy version: {numpy.__version__}'); print(f'NumPy include: {numpy.get_include()}')" || echo "NumPy import failed"
-
-echo "Checking for Eigen..."
-if [[ -d "$PREFIX/include/eigen3" ]]; then
-    echo "✓ Found Eigen3 in $PREFIX/include/eigen3"
-elif [[ -d "$PREFIX/include/Eigen" ]]; then
-    echo "✓ Found Eigen in $PREFIX/include/Eigen"
-else
-    echo "✗ Eigen not found"
-fi
-
-# Debug: Check what GLib/GStreamer paths actually exist
-echo "=== Debug: Checking GLib/GStreamer paths ==="
-echo "PREFIX: $PREFIX"
-ls -la $PREFIX/include/ | grep -E "(glib|gstreamer)" || echo "No glib/gstreamer in include/"
-ls -la $PREFIX/lib/ | grep -E "(glib|gstreamer)" || echo "No glib/gstreamer in lib/"
-ls -la $PREFIX/lib/pkgconfig/ | grep -E "(glib|gstreamer)" || echo "No glib/gstreamer pkgconfig files"
-
-# Check what pkg-config returns for gstreamer
-GSTREAMER_OK=0
-if command -v pkg-config &> /dev/null; then
-    echo "=== pkg-config debug ==="
-    echo "pkg-config version: $(pkg-config --version)"
-    pkg-config --exists gstreamer-1.0 && echo "gstreamer-1.0 found" || echo "gstreamer-1.0 NOT found"
-    pkg-config --exists glib-2.0 && echo "glib-2.0 found" || echo "glib-2.0 NOT found"
-    if pkg-config --exists gstreamer-1.0; then
-        echo "GStreamer cflags: $(pkg-config --cflags gstreamer-1.0)"
-        echo "GStreamer libs: $(pkg-config --libs gstreamer-1.0)"
-        
-        # Check if the include paths in pkg-config actually exist
-        GSTREAMER_CFLAGS=$(pkg-config --cflags gstreamer-1.0)
-        echo "Checking if GStreamer include paths actually exist..."
-        PATHS_VALID=1
-        for flag in $GSTREAMER_CFLAGS; do
-            if [[ $flag == -I* ]]; then
-                path=${flag#-I}
-                if [[ ! -d "$path" ]]; then
-                    echo "WARNING: GStreamer pkg-config references non-existent path: $path"
-                    PATHS_VALID=0
-                fi
-            fi
-        done
-        
-        if [[ $PATHS_VALID -eq 1 ]]; then
-            GSTREAMER_OK=1
-        else
-            echo "GStreamer pkg-config paths are invalid, will disable GStreamer"
-        fi
-    fi
-    if pkg-config --exists glib-2.0; then
-        echo "GLib cflags: $(pkg-config --cflags glib-2.0)"
-        echo "GLib libs: $(pkg-config --libs glib-2.0)"
-    fi
-else
-    echo "pkg-config not found!"
-fi
-echo "=== End debug ==="
-
-# Try manual GStreamer detection as fallback
-if [[ $GSTREAMER_OK -eq 0 ]]; then
-    echo "Attempting manual GStreamer detection..."
-    if [[ -d "$PREFIX/include/gstreamer-1.0" && -f "$PREFIX/lib/libgstreamer-1.0.so" ]]; then
-        echo "Found GStreamer files manually, but pkg-config is broken"
-        echo "Will disable GStreamer to avoid pkg-config issues"
-        GSTREAMER_ENABLE=0
-    else
-        echo "GStreamer files not found manually either"
-        GSTREAMER_ENABLE=0
-    fi
-else
-    echo "GStreamer pkg-config is working correctly"
-    GSTREAMER_ENABLE=1
-fi
-
-# Decide whether to enable GStreamer based on detection
-if [[ $GSTREAMER_ENABLE -eq 1 ]]; then
-    echo "GStreamer appears functional, enabling it"
-else
-    echo "GStreamer detection failed or has invalid paths, disabling it to allow build to proceed"
-    echo "OpenCV will build without GStreamer video support"
-fi
-
-# Create missing glib-2.0 include directory if it doesn't exist
-# This is a workaround for broken conda packages
-if [[ ! -d "$PREFIX/include/glib-2.0" ]]; then
-    echo "Creating missing glib-2.0 include directory as workaround"
-    mkdir -p "$PREFIX/include/glib-2.0"
-    # Create a minimal glib.h if it doesn't exist
-    if [[ ! -f "$PREFIX/include/glib-2.0/glib.h" ]]; then
-        echo "// Dummy glib.h to prevent CMake errors" > "$PREFIX/include/glib-2.0/glib.h"
-    fi
-fi
-
-# Also create the lib/glib-2.0/include directory that's commonly referenced
-if [[ ! -d "$PREFIX/lib/glib-2.0/include" ]]; then
-    echo "Creating missing lib/glib-2.0/include directory as workaround"
-    mkdir -p "$PREFIX/lib/glib-2.0/include"
-    if [[ ! -f "$PREFIX/lib/glib-2.0/include/glibconfig.h" ]]; then
-        echo "// Dummy glibconfig.h to prevent CMake errors" > "$PREFIX/lib/glib-2.0/include/glibconfig.h"
-    fi
-fi
-
-# Set up proper include paths for GLib and GStreamer
-export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
-export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
-
-# Ensure OpenGL libraries can be found for Qt
-if [[ "${target_platform}" == linux-* ]]; then
-    export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
-    # Make sure CMake can find OpenGL libraries
-    export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_gl_LIBRARY=$PREFIX/lib/libGL.so"
-    export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_glu_LIBRARY=$PREFIX/lib/libGLU.so"
-    export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_INCLUDE_DIR=$PREFIX/include/GL"
-    echo "Linux OpenGL setup: libGL.so and libGLU.so detection configured"
-fi
-
-echo "=== Environment Variables Summary ==="
-echo "CPPFLAGS: $CPPFLAGS"
-echo "LDFLAGS: $LDFLAGS"
-echo "CMAKE_ARGS: $CMAKE_ARGS"
-
-echo "=== Qt Detection Debug ==="
-if [[ "$QT" == "6" ]]; then
-    echo "Checking Qt6 installation..."
-    ls -la $PREFIX/lib/ | grep -i qt | head -10 || echo "No Qt libraries found"
-    ls -la $PREFIX/include/ | grep -i qt | head -5 || echo "No Qt headers found"
-    if command -v qmake &> /dev/null; then
-        echo "qmake found: $(which qmake)"
-        qmake -v || echo "qmake version check failed"
-    else
-        echo "qmake not found in PATH"
-    fi
+# Check if GStreamer is available via pkg-config
+GSTREAMER_ENABLE=1
+if ! pkg-config --exists gstreamer-1.0; then
+    GSTREAMER_ENABLE=0
 fi
 
 mkdir -p build${PY_VER}
 cd build${PY_VER}
-
-echo "=== Starting CMake Configuration ==="
-echo "Working directory: $(pwd)"
-echo "CMake command about to be executed..."
 
 # Note that though a dependency may be installed it may not be detected
 # correctly by this build system and so some functionality may be disabled
@@ -239,14 +73,6 @@ echo "CMake command about to be executed..."
 # A number of data files are downloaded when building opencv contrib.
 # We may want to revisit that in a future update.
 # The OPENCV_DOWNLOAD flags are there to make these downloads more robust.
-
-echo "CMake configuration parameters:"
-echo "- BUILD_TYPE: Release"
-echo "- PREFIX_PATH: ${PREFIX}"
-echo "- Qt support: $QT"
-echo "- GStreamer support: $GSTREAMER_ENABLE"
-echo "- OpenMP support: ${OPENMP:-0}"
-echo "- V4L support: $V4L"
 
 cmake -LAH -G "Ninja"                                                     \
     ${CMAKE_ARGS}                                                         \
@@ -343,16 +169,4 @@ cmake -LAH -G "Ninja"                                                     \
     -DOPENCV_PYTHON2_INSTALL_PATH=                                        \
     ..
 
-echo "=== CMake Configuration Complete ==="
-echo "Starting ninja build with $CPU_COUNT cores..."
-echo "Build started at: $(date)"
-
 ninja install -j${CPU_COUNT}
-
-echo "=== Build Complete ==="
-echo "Build finished at: $(date)"
-echo "Checking installed files..."
-ls -la $PREFIX/lib/ | grep opencv | head -10 || echo "No opencv libraries found"
-ls -la $PREFIX/include/ | grep opencv || echo "No opencv headers found"
-
-echo "=== OpenCV Build Script Complete ==="

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -47,27 +47,6 @@ fi
 # FFMPEG building requires pkgconfig
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
 
-# Check if GStreamer is available via pkg-config
-GSTREAMER_ENABLE=1
-if ! pkg-config --exists gstreamer-1.0; then
-    GSTREAMER_ENABLE=0
-fi
-
-# Workaround for missing GLib include directories that GStreamer expects
-if [[ ! -d "$PREFIX/include/glib-2.0" ]]; then
-    mkdir -p "$PREFIX/include/glib-2.0"
-    echo "// Dummy glib.h to prevent CMake errors" > "$PREFIX/include/glib-2.0/glib.h"
-fi
-
-if [[ ! -d "$PREFIX/lib/glib-2.0/include" ]]; then
-    mkdir -p "$PREFIX/lib/glib-2.0/include"
-    echo "// Dummy glibconfig.h to prevent CMake errors" > "$PREFIX/lib/glib-2.0/include/glibconfig.h"
-fi
-
-# Set up include paths for GLib and GStreamer
-export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
-export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/gstreamer-1.0"
-
 mkdir -p build${PY_VER}
 cd build${PY_VER}
 
@@ -138,7 +117,7 @@ cmake -LAH -G "Ninja"                                                     \
     -DWITH_HDF5=1                                                         \
     -DWITH_FFMPEG=1                                                       \
     -DWITH_TENGINE=0                                                      \
-    -DWITH_GSTREAMER=$GSTREAMER_ENABLE                                    \
+    -DWITH_GSTREAMER=1                                                    \
     -DWITH_MATLAB=0                                                       \
     -DWITH_TESSERACT=0                                                    \
     -DWITH_VA=0                                                           \

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -ex
 
+echo "=== OpenCV Build Script Debug Information ==="
+echo "Date: $(date)"
+echo "Build platform: ${build_platform:-unknown}"
+echo "Target platform: ${target_platform:-unknown}"
+echo "Build variant: ${build_variant:-unknown}"
+echo "Python version: ${PY_VER:-unknown}"
+echo "PREFIX: $PREFIX"
+echo "SP_DIR: $SP_DIR"
+echo "CPU_COUNT: ${CPU_COUNT:-unknown}"
+
 # CMake FindPNG seems to look in libpng not libpng16
 # https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindPNG.cmake#L55
 ln -s $PREFIX/include/libpng16 $PREFIX/include/libpng
@@ -12,33 +22,37 @@ if [[ "${target_platform}" == linux-* ]]; then
     # with GCC opencv/issues/8097
     export CXXFLAGS="$CXXFLAGS -D__STDC_CONSTANT_MACROS"
     OPENMP="-DWITH_OPENMP=1"
+    echo "Linux build detected - enabling OpenMP and adding STDC_CONSTANT_MACROS"
 fi
 
 if [[ "$build_variant" == "normal" ]]; then
-    echo "Building normal variant"
+    echo "Building normal variant with Qt6"
     QT="6"
 else
-    echo "Building headless variant"
+    echo "Building headless variant without Qt"
     QT="0"
     echo $QT
 fi
 
 if [[ "${target_platform}" == osx-* ]]; then
     V4L="0"
+    echo "macOS build detected - disabling V4L"
 elif [[ "${target_platform}" == linux-ppc64le ]]; then
     OPENVINO="0"
+    echo "Linux PPC64LE build detected - disabling OpenVINO"
 fi
-
 
 if [[ "${target_platform}" != "${build_platform}" ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc"
     CMAKE_ARGS="${CMAKE_ARGS} -DQT_HOST_PATH=${BUILD_PREFIX}"
+    echo "Cross-compilation detected - setting protoc and Qt host paths"
 fi
-
 
 export PKG_CONFIG_LIBDIR=$PREFIX/lib
 
 IS_PYPY=$(${PYTHON} -c "import platform; print(int(platform.python_implementation() == 'PyPy'))")
+echo "Python implementation: $(${PYTHON} -c "import platform; print(platform.python_implementation())")"
+echo "Is PyPy: $IS_PYPY"
 
 LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER}${SHLIB_EXT}"
 if [[ ${IS_PYPY} == "1" ]]; then
@@ -47,8 +61,127 @@ else
     INC_PYTHON="$PREFIX/include/python${PY_VER}"
 fi
 
+echo "Python library: $LIB_PYTHON"
+echo "Python include: $INC_PYTHON"
+
 # FFMPEG building requires pkgconfig
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
+echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
+echo "PKG_CONFIG_LIBDIR: $PKG_CONFIG_LIBDIR"
+
+# Debug: Check critical dependencies
+echo "=== Debug: Checking critical dependencies ==="
+echo "Checking for essential libraries and headers..."
+for lib in libz libpng libjpeg libtiff libwebp libopenjpeg libprotobuf libhdf5; do
+    if [[ -f "$PREFIX/lib/${lib}.so" || -f "$PREFIX/lib/${lib}.dylib" || -f "$PREFIX/lib/${lib}.a" ]]; then
+        echo "✓ Found: $lib"
+    else
+        echo "✗ Missing: $lib"
+    fi
+done
+
+echo "Checking for Python NumPy..."
+${PYTHON} -c "import numpy; print(f'NumPy version: {numpy.__version__}'); print(f'NumPy include: {numpy.get_include()}')" || echo "NumPy import failed"
+
+echo "Checking for Eigen..."
+if [[ -d "$PREFIX/include/eigen3" ]]; then
+    echo "✓ Found Eigen3 in $PREFIX/include/eigen3"
+elif [[ -d "$PREFIX/include/Eigen" ]]; then
+    echo "✓ Found Eigen in $PREFIX/include/Eigen"
+else
+    echo "✗ Eigen not found"
+fi
+
+# Debug: Check what GLib/GStreamer paths actually exist
+echo "=== Debug: Checking GLib/GStreamer paths ==="
+echo "PREFIX: $PREFIX"
+ls -la $PREFIX/include/ | grep -E "(glib|gstreamer)" || echo "No glib/gstreamer in include/"
+ls -la $PREFIX/lib/ | grep -E "(glib|gstreamer)" || echo "No glib/gstreamer in lib/"
+ls -la $PREFIX/lib/pkgconfig/ | grep -E "(glib|gstreamer)" || echo "No glib/gstreamer pkgconfig files"
+
+# Check what pkg-config returns for gstreamer
+GSTREAMER_OK=0
+if command -v pkg-config &> /dev/null; then
+    echo "=== pkg-config debug ==="
+    echo "pkg-config version: $(pkg-config --version)"
+    pkg-config --exists gstreamer-1.0 && echo "gstreamer-1.0 found" || echo "gstreamer-1.0 NOT found"
+    pkg-config --exists glib-2.0 && echo "glib-2.0 found" || echo "glib-2.0 NOT found"
+    if pkg-config --exists gstreamer-1.0; then
+        echo "GStreamer cflags: $(pkg-config --cflags gstreamer-1.0)"
+        echo "GStreamer libs: $(pkg-config --libs gstreamer-1.0)"
+        
+        # Check if the include paths in pkg-config actually exist
+        GSTREAMER_CFLAGS=$(pkg-config --cflags gstreamer-1.0)
+        echo "Checking if GStreamer include paths actually exist..."
+        PATHS_VALID=1
+        for flag in $GSTREAMER_CFLAGS; do
+            if [[ $flag == -I* ]]; then
+                path=${flag#-I}
+                if [[ ! -d "$path" ]]; then
+                    echo "WARNING: GStreamer pkg-config references non-existent path: $path"
+                    PATHS_VALID=0
+                fi
+            fi
+        done
+        
+        if [[ $PATHS_VALID -eq 1 ]]; then
+            GSTREAMER_OK=1
+        else
+            echo "GStreamer pkg-config paths are invalid, will disable GStreamer"
+        fi
+    fi
+    if pkg-config --exists glib-2.0; then
+        echo "GLib cflags: $(pkg-config --cflags glib-2.0)"
+        echo "GLib libs: $(pkg-config --libs glib-2.0)"
+    fi
+else
+    echo "pkg-config not found!"
+fi
+echo "=== End debug ==="
+
+# Try manual GStreamer detection as fallback
+if [[ $GSTREAMER_OK -eq 0 ]]; then
+    echo "Attempting manual GStreamer detection..."
+    if [[ -d "$PREFIX/include/gstreamer-1.0" && -f "$PREFIX/lib/libgstreamer-1.0.so" ]]; then
+        echo "Found GStreamer files manually, but pkg-config is broken"
+        echo "Will disable GStreamer to avoid pkg-config issues"
+        GSTREAMER_ENABLE=0
+    else
+        echo "GStreamer files not found manually either"
+        GSTREAMER_ENABLE=0
+    fi
+else
+    echo "GStreamer pkg-config is working correctly"
+    GSTREAMER_ENABLE=1
+fi
+
+# Decide whether to enable GStreamer based on detection
+if [[ $GSTREAMER_ENABLE -eq 1 ]]; then
+    echo "GStreamer appears functional, enabling it"
+else
+    echo "GStreamer detection failed or has invalid paths, disabling it to allow build to proceed"
+    echo "OpenCV will build without GStreamer video support"
+fi
+
+# Create missing glib-2.0 include directory if it doesn't exist
+# This is a workaround for broken conda packages
+if [[ ! -d "$PREFIX/include/glib-2.0" ]]; then
+    echo "Creating missing glib-2.0 include directory as workaround"
+    mkdir -p "$PREFIX/include/glib-2.0"
+    # Create a minimal glib.h if it doesn't exist
+    if [[ ! -f "$PREFIX/include/glib-2.0/glib.h" ]]; then
+        echo "// Dummy glib.h to prevent CMake errors" > "$PREFIX/include/glib-2.0/glib.h"
+    fi
+fi
+
+# Also create the lib/glib-2.0/include directory that's commonly referenced
+if [[ ! -d "$PREFIX/lib/glib-2.0/include" ]]; then
+    echo "Creating missing lib/glib-2.0/include directory as workaround"
+    mkdir -p "$PREFIX/lib/glib-2.0/include"
+    if [[ ! -f "$PREFIX/lib/glib-2.0/include/glibconfig.h" ]]; then
+        echo "// Dummy glibconfig.h to prevent CMake errors" > "$PREFIX/lib/glib-2.0/include/glibconfig.h"
+    fi
+fi
 
 # Set up proper include paths for GLib and GStreamer
 export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/glib-2.0 -I$PREFIX/lib/glib-2.0/include"
@@ -61,10 +194,33 @@ if [[ "${target_platform}" == linux-* ]]; then
     export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_gl_LIBRARY=$PREFIX/lib/libGL.so"
     export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_glu_LIBRARY=$PREFIX/lib/libGLU.so"
     export CMAKE_ARGS="$CMAKE_ARGS -DOPENGL_INCLUDE_DIR=$PREFIX/include/GL"
+    echo "Linux OpenGL setup: libGL.so and libGLU.so detection configured"
+fi
+
+echo "=== Environment Variables Summary ==="
+echo "CPPFLAGS: $CPPFLAGS"
+echo "LDFLAGS: $LDFLAGS"
+echo "CMAKE_ARGS: $CMAKE_ARGS"
+
+echo "=== Qt Detection Debug ==="
+if [[ "$QT" == "6" ]]; then
+    echo "Checking Qt6 installation..."
+    ls -la $PREFIX/lib/ | grep -i qt | head -10 || echo "No Qt libraries found"
+    ls -la $PREFIX/include/ | grep -i qt | head -5 || echo "No Qt headers found"
+    if command -v qmake &> /dev/null; then
+        echo "qmake found: $(which qmake)"
+        qmake -v || echo "qmake version check failed"
+    else
+        echo "qmake not found in PATH"
+    fi
 fi
 
 mkdir -p build${PY_VER}
 cd build${PY_VER}
+
+echo "=== Starting CMake Configuration ==="
+echo "Working directory: $(pwd)"
+echo "CMake command about to be executed..."
 
 # Note that though a dependency may be installed it may not be detected
 # correctly by this build system and so some functionality may be disabled
@@ -83,6 +239,15 @@ cd build${PY_VER}
 # A number of data files are downloaded when building opencv contrib.
 # We may want to revisit that in a future update.
 # The OPENCV_DOWNLOAD flags are there to make these downloads more robust.
+
+echo "CMake configuration parameters:"
+echo "- BUILD_TYPE: Release"
+echo "- PREFIX_PATH: ${PREFIX}"
+echo "- Qt support: $QT"
+echo "- GStreamer support: $GSTREAMER_ENABLE"
+echo "- OpenMP support: ${OPENMP:-0}"
+echo "- V4L support: $V4L"
+
 cmake -LAH -G "Ninja"                                                     \
     ${CMAKE_ARGS}                                                         \
     -DCMAKE_BUILD_TYPE="Release"                                          \
@@ -132,7 +297,7 @@ cmake -LAH -G "Ninja"                                                     \
     -DWITH_HDF5=1                                                         \
     -DWITH_FFMPEG=1                                                       \
     -DWITH_TENGINE=0                                                      \
-    -DWITH_GSTREAMER=1                                                    \
+    -DWITH_GSTREAMER=$GSTREAMER_ENABLE                                    \
     -DWITH_MATLAB=0                                                       \
     -DWITH_TESSERACT=0                                                    \
     -DWITH_VA=0                                                           \
@@ -178,4 +343,16 @@ cmake -LAH -G "Ninja"                                                     \
     -DOPENCV_PYTHON2_INSTALL_PATH=                                        \
     ..
 
+echo "=== CMake Configuration Complete ==="
+echo "Starting ninja build with $CPU_COUNT cores..."
+echo "Build started at: $(date)"
+
 ninja install -j${CPU_COUNT}
+
+echo "=== Build Complete ==="
+echo "Build finished at: $(date)"
+echo "Checking installed files..."
+ls -la $PREFIX/lib/ | grep opencv | head -10 || echo "No opencv libraries found"
+ls -la $PREFIX/include/ | grep opencv || echo "No opencv headers found"
+
+echo "=== OpenCV Build Script Complete ==="

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,3 @@ build_variant:
   - normal
   # As of 5/30/2022 headless is only to be available on the sfe1ed40 channel
   # - headless
-
-harfbuzz:
-  - 10

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,6 @@ build_variant:
   - normal
   # As of 5/30/2022 headless is only to be available on the sfe1ed40 channel
   # - headless
+
+qt_version:
+  - "6"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,3 @@ build_variant:
   - normal
   # As of 5/30/2022 headless is only to be available on the sfe1ed40 channel
   # - headless
-
-qt_version:
-  - "6"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,7 +135,7 @@ outputs:
         - libabseil
         - libtiff
         - libwebp-base
-        - qtbase         # [build_variant == "normal"]
+        - qtbase-devel 6  # [build_variant == "normal"]
         - zlib
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,21 +105,11 @@ outputs:
         - libabseil 20250127.0
         - libtiff {{ libtiff }}
         - libwebp-base {{ libwebp }}
+        # Note: X11/Xorg/XCB/OpenGL packages are handled by qtbase's run_exports
+        # OpenCV uses Qt for GUI functionality, so no direct X11 dependencies needed
         - qtbase 6                 # [build_variant == "normal"]
         - qt5compat                # [build_variant == "normal"]
         - zlib {{ zlib }}
-        - libegl-devel             # [linux]
-        - libgl-devel              # [linux]
-        - libxcb                   # [linux]
-        - mesalib                  # [linux]
-        - xorg-libx11              # [linux]
-        - xorg-libxau              # [linux]
-        - xorg-libxdamage          # [linux]
-        - xorg-libxext             # [linux]
-        - xorg-libxfixes           # [linux]
-        - xorg-libxi               # [linux]
-        - xorg-libxrender          # [linux]
-        - xorg-libxxf86vm          # [linux]
       run:
         - _openmp_mutex         # [linux]
         - python
@@ -154,6 +144,8 @@ outputs:
           - cmake
           - ninja
           - pip
+          # X11/OpenGL packages kept in test for proper testing of OpenCV functionality
+          # even though qtbase handles these dependencies at runtime
           - libegl-devel                   # [linux]
           - libgl-devel                    # [linux]
           - mesalib                        # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,19 +87,12 @@ outputs:
         # pkg-config on win pulls in python
         # adding here explicitly to pull in the same version as in host
         - python                         # [win]
-        - {{ cdt('libselinux') }}        # [linux]
-        - {{ cdt('libxau-devel') }}      # [linux]
-        - {{ cdt('libxcb') }}            # [linux]
-        - {{ cdt('libxdamage-devel') }}  # [linux]
-        - {{ cdt('libxext-devel') }}     # [linux]
-        - {{ cdt('libxfixes-devel') }}   # [linux]
-        - {{ cdt('libxi-devel') }}       # [linux]
-        - {{ cdt('libxrender-devel') }}  # [linux]
-        - {{ cdt('libxxf86vm') }}        # [linux]
-        - {{ cdt('mesa-libegl-devel') }} # [linux]
-        - {{ cdt('mesa-libgbm') }}       # [linux]
-        - {{ cdt('mesa-libgl-devel') }}  # [linux]
-        - {{ cdt('mesa-dri-drivers') }}  # [linux]
+        # TODO: map CDT libselinux to new X11 package
+        # - { cdt('libselinux') }
+        # TODO: map CDT mesa-libegl-devel to new X11 package
+        # - { cdt('mesa-libegl-devel') }
+        # TODO: map CDT mesa-libgbm to new X11 package
+        # - { cdt('mesa-libgbm') }
       host:
         - python
         - numpy {{ numpy }}
@@ -123,6 +116,21 @@ outputs:
         - qtbase 6                 # [build_variant == "normal"]
         - qt5compat                # [build_variant == "normal"]
         - zlib {{ zlib }}
+        - xorg-libxau
+        - libxcb
+        - xorg-libxdamage
+        - xorg-libxext
+        - xorg-libxfixes
+        - xorg-libxi
+        - xorg-libxrender
+        - xorg-libxxf86vm
+        - libgl-devel
+        - mesa-dri-drivers
+          - xorg-libxext
+          - xorg-libxdamage
+          - xorg-libxfixes
+          - xorg-libxxf86vm
+          - mesa-dri-drivers
       run:
         - _openmp_mutex         # [linux]
         - python
@@ -157,16 +165,16 @@ outputs:
           - cmake
           - ninja
           - pip
-          - {{ cdt('mesa-libgl') }}        # [linux]
-          - {{ cdt('libx11') }}            # [linux]
-          - {{ cdt('libxau') }}            # [linux]
-          - {{ cdt('libxext') }}           # [linux]
-          - {{ cdt('libxdamage') }}        # [linux]
-          - {{ cdt('libxfixes') }}         # [linux]
-          - {{ cdt('libxxf86vm') }}        # [linux]
-          - {{ cdt('mesa-dri-drivers') }}  # [linux]
-          - {{ cdt('mesa-libegl') }}       # [linux]
-          - {{ cdt('mesa-libgbm') }}       # [linux]
+          # TODO: map CDT mesa-libgl to new X11 package
+          # - { cdt('mesa-libgl') }
+          # TODO: map CDT libx11 to new X11 package
+          # - { cdt('libx11') }
+          # TODO: map CDT libxau to new X11 package
+          # - { cdt('libxau') }
+          # TODO: map CDT mesa-libegl to new X11 package
+          # - { cdt('mesa-libegl') }
+          # TODO: map CDT mesa-libgbm to new X11 package
+          # - { cdt('mesa-libgbm') }
         files:
           - CMakeLists.txt
           - test.cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,6 +102,8 @@ outputs:
         - jpeg {{ jpeg }}
         - libabseil {{ libabseil }}
         - glib {{ glib }}
+        # libglib is needed to satisfy the linter
+        - libglib {{ glib }}
         - glog {{ glog }}
         - libiconv {{ libiconv }}          # [unix]
         - libpng {{ libpng }}
@@ -117,7 +119,7 @@ outputs:
       run:
         - _openmp_mutex         # [linux]
         - python
-        - {{ pin_compatible('numpy') }}
+        - numpy
         # bounds set through run exports
         - eigen
         - ffmpeg                # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,7 @@ outputs:
         - hdf5 {{ hdf5 }}
         - jpeg {{ jpeg }}
         - libabseil {{ libabseil }}
-        - libglib {{ glib }}
+        - glib {{ glib }}
         - libiconv {{ libiconv }}                  # [unix]
         - libpng {{ libpng }}
         - libprotobuf {{ libprotobuf }}
@@ -124,7 +124,7 @@ outputs:
         - ffmpeg                # [not win]
         - freetype
         - harfbuzz
-        - libglib
+        - glib
         - gst-plugins-base
         - gstreamer
         - hdf5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,7 +90,7 @@ outputs:
         - ninja-base
         # pkg-config on win pulls in python
         # adding here explicitly to pull in the same version as in host
-        - python 3.12                   # [win]
+        - python 3.9                   # [win]
       host:
         - python
         - eigen 3.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,10 @@ outputs:
       ignore_run_exports:
         # qt5compat is needed for a CMake find_package() call but is not actually used in OpenCV anymore.
         - qt5compat
+        # GStreamer libraries - OpenCV uses them but they don't need explicit run_exports
+        - gst-plugins-base
+        - gstreamer
+        - libglib
     run_exports:
       # We are cautiously optimistic here that patch-level updates won't break
       # ABI. However, it sounds like upstream won't guarantee *any* sort of
@@ -99,25 +103,16 @@ outputs:
         - hdf5 {{ hdf5 }}
         - jpeg {{ jpeg }}
         - libabseil {{ libabseil }}
-        # Essential X11/OpenGL libraries for Qt to function properly
-        - libegl                         # [linux]
-        - libgl-devel                    # [linux]
         - libglib {{ glib }}
         - libiconv {{ libiconv }}                  # [unix]
         - libpng {{ libpng }}
         - libprotobuf {{ libprotobuf }}
         - libtiff {{ libtiff }}
         - libwebp-base {{ libwebp }}
-        - libxcb                         # [linux]
-        - mesalib                        # [linux]
         - numpy {{ numpy }}
         - openjpeg {{ openjpeg }}
         - qtbase-devel 6                 # [build_variant == "normal"]
         - qt5compat                      # [build_variant == "normal"]
-        - xorg-libx11                    # [linux]
-        - xorg-libxau                    # [linux]
-        - xorg-libxext                   # [linux]
-        - xorg-xorgproto                 # [linux]
         - zlib {{ zlib }}
       run:
         - _openmp_mutex         # [linux]
@@ -140,7 +135,7 @@ outputs:
         - libabseil
         - libtiff
         - libwebp-base
-        - qtbase          # [build_variant == "normal"]
+        - qtbase-devel         # [build_variant == "normal"]
         - zlib
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -138,8 +138,6 @@ outputs:
         - libwebp-base
         - qtbase          # [build_variant == "normal"]
         - zlib
-        # OpenGL implementation needed at runtime since OpenCV links against libgl
-        - mesalib         # [linux]
 
     test:
         source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,13 +65,12 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_num }}
+      script_env:
+        - QT={{ qt_version }}  # [build_variant == "normal"]
+        - QT=0                 # [build_variant == "headless"]
       ignore_run_exports:
         # qt5compat is needed for a CMake find_package() call but is not actually used in OpenCV anymore.
         - qt5compat
-        # GStreamer libraries - OpenCV uses them but they don't need explicit run_exports
-        - gst-plugins-base
-        - gstreamer
-        - glib
     run_exports:
       # We are cautiously optimistic here that patch-level updates won't break
       # ABI. However, it sounds like upstream won't guarantee *any* sort of
@@ -89,8 +88,7 @@ outputs:
         - cmake
         - ninja-base
         # pkg-config on win pulls in python
-        # adding here explicitly to pull in the same version as in host
-        - python 3.9                   # [win]
+        - python                        # [win]
       host:
         - python
         - eigen 3.4.0
@@ -103,8 +101,8 @@ outputs:
         - hdf5 {{ hdf5 }}
         - jpeg {{ jpeg }}
         - libabseil {{ libabseil }}
-        - glib {{ glib }}                  # [not osx]
-        - libglib {{ glib }}               # [osx]
+        - glib {{ glib }}
+        - glog {{ glog }}
         - libiconv {{ libiconv }}          # [unix]
         - libpng {{ libpng }}
         - libprotobuf {{ libprotobuf }}
@@ -112,7 +110,7 @@ outputs:
         - libwebp-base {{ libwebp }}
         - numpy {{ numpy }}
         - openjpeg {{ openjpeg }}
-        - qtbase-devel 6                 # [build_variant == "normal"]
+        - qtbase-devel {{ qt_version }}  # [build_variant == "normal"]
         - qt5compat                      # [build_variant == "normal"]
         - libgl-devel {{ libgl }}        # [linux]
         - zlib {{ zlib }}
@@ -125,8 +123,7 @@ outputs:
         - ffmpeg                # [not win]
         - freetype
         - harfbuzz
-        - glib                             # [not osx]
-        - libglib                          # [osx]
+        - libglib
         - gst-plugins-base
         - gstreamer
         - hdf5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,9 +88,9 @@ outputs:
         - pkg-config
         - cmake
         - ninja-base
-        # pkg-config on win pulls in python
+        # pkg-config on win and osx pulls in python
         # adding here explicitly to pull in the same version as in host
-        - python                         # [win]
+        - python 3.12                   # [win or osx]
       host:
         - python
         - eigen 3.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -148,14 +148,6 @@ outputs:
           - cmake
           - ninja
           - pip
-          # X11/OpenGL packages kept in test for proper testing of OpenCV functionality
-          # even though qtbase handles these dependencies at runtime
-          - libegl-devel                   # [linux]
-          - mesalib                        # [linux]
-          - qtbase                         # [linux and build_variant == "normal"]
-          - xorg-libx11                    # [linux]
-          - xorg-libxau                    # [linux]
-          - xorg-xorgproto                 # [linux]
         files:
           - CMakeLists.txt
           - test.cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,28 +87,35 @@ outputs:
         - python                         # [win]
       host:
         - python
-        - numpy {{ numpy }}
         - eigen 3.4.0
-        - ffmpeg 6                  # [not win]
+        - ffmpeg {{ ffmpeg }}           # [not win]
         - freetype {{ freetype }}
+        - gst-plugins-base {{ gst_plugins_base }}
+        - gstreamer {{ gstreamer }}
         # harfbuzz, glib, gettext are both needed for freetype support
         - harfbuzz {{ harfbuzz }}
-        - libglib {{ glib }}
-        - gstreamer 1.24
-        - gst-plugins-base 1.24
         - hdf5 {{ hdf5 }}
         - jpeg {{ jpeg }}
-        - openjpeg 2.5.2
-        - libiconv 1.16             # [unix]
-        - libpng  {{ libpng }}
-        - libprotobuf 5.29.3
-        - libabseil 20250127.0
+        - libabseil {{ libabseil }}
+        # Essential X11/OpenGL libraries for Qt to function properly
+        - libegl                         # [linux]
+        - libgl-devel                    # [linux]
+        - libglib {{ glib }}
+        - libiconv {{ libiconv }}                  # [unix]
+        - libpng {{ libpng }}
+        - libprotobuf {{ libprotobuf }}
         - libtiff {{ libtiff }}
         - libwebp-base {{ libwebp }}
-        # Note: X11/Xorg/XCB/OpenGL packages are handled by qtbase's run_exports
-        # OpenCV uses Qt for GUI functionality, so no direct X11 dependencies needed
-        - qtbase 6                 # [build_variant == "normal"]
-        - qt5compat                # [build_variant == "normal"]
+        - libxcb                         # [linux]
+        - mesalib                        # [linux]
+        - numpy {{ numpy }}
+        - openjpeg {{ openjpeg }}
+        - qtbase-devel 6                 # [build_variant == "normal"]
+        - qt5compat                      # [build_variant == "normal"]
+        - xorg-libx11                    # [linux]
+        - xorg-libxau                    # [linux]
+        - xorg-libxext                   # [linux]
+        - xorg-xorgproto                 # [linux]
         - zlib {{ zlib }}
       run:
         - _openmp_mutex         # [linux]
@@ -149,6 +156,7 @@ outputs:
           - libegl-devel                   # [linux]
           - libgl-devel                    # [linux]
           - mesalib                        # [linux]
+          - qtbase-devel                   # [linux and build_variant == "normal"]
           - xorg-libx11                    # [linux]
           - xorg-libxau                    # [linux]
           - xorg-xorgproto                 # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,13 +114,6 @@ outputs:
         - qtbase-devel 6                 # [build_variant == "normal"]
         - qt5compat                      # [build_variant == "normal"]
         - zlib {{ zlib }}
-        # Essential X11/OpenGL libraries for OpenCV functionality on Linux
-        - libgl-devel                    # [linux]
-        - libxcb                         # [linux]
-        - mesalib                        # [linux]
-        - xorg-libx11                    # [linux]
-        - xorg-libxext                   # [linux]
-        - xorg-xorgproto                 # [linux]
       run:
         - _openmp_mutex         # [linux]
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,9 +88,9 @@ outputs:
         - pkg-config
         - cmake
         - ninja-base
-        # pkg-config on win and osx pulls in python
+        # pkg-config on win pulls in python
         # adding here explicitly to pull in the same version as in host
-        - python 3.12                   # [win or osx]
+        - python 3.12                   # [win]
       host:
         - python
         - eigen 3.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -113,6 +113,7 @@ outputs:
         - openjpeg {{ openjpeg }}
         - qtbase-devel 6                 # [build_variant == "normal"]
         - qt5compat                      # [build_variant == "normal"]
+        - libgl-devel {{ libgl }}        # [linux]
         - zlib {{ zlib }}
       run:
         - _openmp_mutex         # [linux]
@@ -135,8 +136,10 @@ outputs:
         - libabseil
         - libtiff
         - libwebp-base
-        - qtbase-devel 6  # [build_variant == "normal"]
+        - qtbase          # [build_variant == "normal"]
         - zlib
+        # OpenGL implementation needed at runtime since OpenCV links against libgl
+        - mesalib         # [linux]
 
     test:
         source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,8 +66,8 @@ outputs:
     build:
       number: {{ build_num }}
       script_env:
-        - QT={{ qt_version }}  # [build_variant == "normal"]
-        - QT=0                 # [build_variant == "headless"]
+        - QT={{ qt.split(".")[0] }}  # [build_variant == "normal"]
+        - QT=0                       # [build_variant == "headless"]
       ignore_run_exports:
         # qt5compat is needed for a CMake find_package() call but is not actually used in OpenCV anymore.
         - qt5compat
@@ -110,9 +110,9 @@ outputs:
         - libwebp-base {{ libwebp }}
         - numpy {{ numpy }}
         - openjpeg {{ openjpeg }}
-        - qtbase-devel {{ qt_version }}  # [build_variant == "normal"]
-        - qt5compat                      # [build_variant == "normal"]
-        - libgl-devel {{ libgl }}        # [linux]
+        - qtbase-devel {{ qt }}  # [build_variant == "normal"]
+        - qt5compat              # [build_variant == "normal"]
+        - libgl-devel {{ libgl }}  # [linux]
         - zlib {{ zlib }}
       run:
         - _openmp_mutex         # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,6 +82,7 @@ outputs:
       - {{ pin_subpackage('opencv-python-headless', max_pin='x.x') }} # [build_variant == 'headless']
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,8 @@ source:
 
 build:
   number: {{ build_num }}
+  # qtbase isn't available for osx-64
+  skip: True  # [osx and x86_64]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.10.0" %}
-{% set build_num = "6" %}
+{% set build_num = "7" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
@@ -50,8 +50,6 @@ source:
 
 build:
   number: {{ build_num }}
-  # Package not supported on s390x
-  skip: true  # [s390x]
 
 requirements:
   build:
@@ -87,12 +85,6 @@ outputs:
         # pkg-config on win pulls in python
         # adding here explicitly to pull in the same version as in host
         - python                         # [win]
-        # TODO: map CDT libselinux to new X11 package
-        # - { cdt('libselinux') }
-        # TODO: map CDT mesa-libegl-devel to new X11 package
-        # - { cdt('mesa-libegl-devel') }
-        # TODO: map CDT mesa-libgbm to new X11 package
-        # - { cdt('mesa-libgbm') }
       host:
         - python
         - numpy {{ numpy }}
@@ -116,21 +108,18 @@ outputs:
         - qtbase 6                 # [build_variant == "normal"]
         - qt5compat                # [build_variant == "normal"]
         - zlib {{ zlib }}
-        - xorg-libxau
-        - libxcb
-        - xorg-libxdamage
-        - xorg-libxext
-        - xorg-libxfixes
-        - xorg-libxi
-        - xorg-libxrender
-        - xorg-libxxf86vm
-        - libgl-devel
-        - mesa-dri-drivers
-          - xorg-libxext
-          - xorg-libxdamage
-          - xorg-libxfixes
-          - xorg-libxxf86vm
-          - mesa-dri-drivers
+        - libegl-devel             # [linux]
+        - libgl-devel              # [linux]
+        - libxcb                   # [linux]
+        - mesalib                  # [linux]
+        - xorg-libx11              # [linux]
+        - xorg-libxau              # [linux]
+        - xorg-libxdamage          # [linux]
+        - xorg-libxext             # [linux]
+        - xorg-libxfixes           # [linux]
+        - xorg-libxi               # [linux]
+        - xorg-libxrender          # [linux]
+        - xorg-libxxf86vm          # [linux]
       run:
         - _openmp_mutex         # [linux]
         - python
@@ -165,16 +154,12 @@ outputs:
           - cmake
           - ninja
           - pip
-          # TODO: map CDT mesa-libgl to new X11 package
-          # - { cdt('mesa-libgl') }
-          # TODO: map CDT libx11 to new X11 package
-          # - { cdt('libx11') }
-          # TODO: map CDT libxau to new X11 package
-          # - { cdt('libxau') }
-          # TODO: map CDT mesa-libegl to new X11 package
-          # - { cdt('mesa-libegl') }
-          # TODO: map CDT mesa-libgbm to new X11 package
-          # - { cdt('mesa-libgbm') }
+          - libegl-devel                   # [linux]
+          - libgl-devel                    # [linux]
+          - mesalib                        # [linux]
+          - xorg-libx11                    # [linux]
+          - xorg-libxau                    # [linux]
+          - xorg-xorgproto                 # [linux]
         files:
           - CMakeLists.txt
           - test.cpp
@@ -183,6 +168,9 @@ outputs:
           - color_palette_alpha.png
           - test_1_c1.jpg
         commands:
+          # Verify pkg-config functionality
+          - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig                        # [linux]
+          - pkg-config --cflags opencv4                                         # [linux]
           # Verify dynamic libraries on all systems
           {% set win_ver_lib = version|replace(".", "") %}
           # The bot doesn't support multiline jinja, so use

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
         # GStreamer libraries - OpenCV uses them but they don't need explicit run_exports
         - gst-plugins-base
         - gstreamer
-        - libglib
+        - glib
     run_exports:
       # We are cautiously optimistic here that patch-level updates won't break
       # ABI. However, it sounds like upstream won't guarantee *any* sort of
@@ -103,8 +103,9 @@ outputs:
         - hdf5 {{ hdf5 }}
         - jpeg {{ jpeg }}
         - libabseil {{ libabseil }}
-        - glib {{ glib }}
-        - libiconv {{ libiconv }}                  # [unix]
+        - glib {{ glib }}                  # [not osx]
+        - libglib {{ glib }}               # [osx]
+        - libiconv {{ libiconv }}          # [unix]
         - libpng {{ libpng }}
         - libprotobuf {{ libprotobuf }}
         - libtiff {{ libtiff }}
@@ -124,7 +125,8 @@ outputs:
         - ffmpeg                # [not win]
         - freetype
         - harfbuzz
-        - glib
+        - glib                             # [not osx]
+        - libglib                          # [osx]
         - gst-plugins-base
         - gstreamer
         - hdf5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,6 +114,13 @@ outputs:
         - qtbase-devel 6                 # [build_variant == "normal"]
         - qt5compat                      # [build_variant == "normal"]
         - zlib {{ zlib }}
+        # Essential X11/OpenGL libraries for OpenCV functionality on Linux
+        - libgl-devel                    # [linux]
+        - libxcb                         # [linux]
+        - mesalib                        # [linux]
+        - xorg-libx11                    # [linux]
+        - xorg-libxext                   # [linux]
+        - xorg-xorgproto                 # [linux]
       run:
         - _openmp_mutex         # [linux]
         - python
@@ -135,7 +142,7 @@ outputs:
         - libabseil
         - libtiff
         - libwebp-base
-        - qtbase-devel         # [build_variant == "normal"]
+        - qtbase         # [build_variant == "normal"]
         - zlib
 
     test:
@@ -151,9 +158,8 @@ outputs:
           # X11/OpenGL packages kept in test for proper testing of OpenCV functionality
           # even though qtbase handles these dependencies at runtime
           - libegl-devel                   # [linux]
-          - libgl-devel                    # [linux]
           - mesalib                        # [linux]
-          - qtbase-devel                   # [linux and build_variant == "normal"]
+          - qtbase                         # [linux and build_variant == "normal"]
           - xorg-libx11                    # [linux]
           - xorg-libxau                    # [linux]
           - xorg-xorgproto                 # [linux]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7751](https://anaconda.atlassian.net/browse/PKG-7751) 
- [Upstream repository](https://github.com/opencv/opencv/tree/4.10.0)

### Explanation of changes:

- Handle glib/gstreamer issues on osx-arm64. Only libglib is required on osx, but glib on other platforms
- Enable opengl on linux
- Pin host dependencies

### Notes:

- Automated migration/rebuild for group x11_gui_rebuilds.


[PKG-7751]: https://anaconda.atlassian.net/browse/PKG-7751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ