### PR TITLE
opencv 4.12.0

### DIFF
--- a/recipe/CMakeLists.txt
+++ b/recipe/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Mostly follows <opencv>/samples/cpp/example_cmake/CMakeLists.txt
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(cmake_build_test)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)

--- a/recipe/build_opencv.bat
+++ b/recipe/build_opencv.bat
@@ -6,15 +6,16 @@ if "%build_variant%" == "normal" (
 ) else (
   echo "Building headless variant without Qt"
 )
+:REM hmaarrfk -- 2025/05
+:REM Qt 6.9 seems to be injecting bad flags into the build process
+:REM https://github.com/conda-forge/qt-main-feedstock/issues/332
+if "%QT%"=="6" python -c "import os; p = os.path.join(os.environ['LIBRARY_PREFIX'], 'lib', 'cmake', 'Qt6Test', 'Qt6TestTargets.cmake'); lines = open(p).readlines(); open(p, 'w').writelines(l for l in lines if 'INTERFACE_COMPILE_DEFINITIONS' not in l)"
 
 for /F "tokens=1,2 delims=. " %%a in ("%PY_VER%") do (
    set "PY_MAJOR=%%a"
    set "PY_MINOR=%%b"
 )
 set PY_LIB=python%PY_MAJOR%%PY_MINOR%.lib
-
-mkdir build%PY_MAJOR%%PY_MINOR%
-cd build%PY_MAJOR%%PY_MINOR%
 
 :: Workaround for building LAPACK headers with C++17
 :: see https://github.com/conda-forge/opencv-feedstock/pull/363#issuecomment-1604972688
@@ -50,92 +51,95 @@ rem A number of data files are downloaded when building opencv contrib.
 rem We may want to revisit that in a future update.
 rem The OPENCV_DOWNLOAD flags are there to make these downloads more robust.
 rem ENABLE_PRECOMPILED_HEADERS is deprecated on win and set to OFF as such.
-cmake -LAH -G "Ninja"                                                               ^
-    -DCMAKE_BUILD_TYPE="Release"                                                    ^
-    -DCMAKE_INSTALL_PREFIX=%UNIX_LIBRARY_PREFIX%                                    ^
-    -DCMAKE_PREFIX_PATH=%UNIX_LIBRARY_PREFIX%                                       ^
-    -DOPENCV_CONFIG_INSTALL_PATH=cmake                                              ^
-    -DOPENCV_BIN_INSTALL_PATH=bin                                                   ^
-    -DOPENCV_LIB_INSTALL_PATH=lib                                                   ^
-    -DOPENCV_GENERATE_SETUPVARS=OFF                                                 ^
-    -DOPENCV_DOWNLOAD_TRIES=1;2;3;4;5                                               ^
-    -DOPENCV_DOWNLOAD_PARAMS=INACTIVITY_TIMEOUT;30;TIMEOUT;180;SHOW_PROGRESS        ^
-    -DOPENCV_GENERATE_PKGCONFIG=OFF                                                 ^
-    -DENABLE_CONFIG_VERIFICATION=ON                                                 ^
-    -DENABLE_PRECOMPILED_HEADERS=OFF                                                ^
-    -DWITH_LAPACK=0                                                                 ^
-    -DCMAKE_CXX_STANDARD=17                                                         ^
-    -DWITH_EIGEN=1                                                                  ^
-    -DBUILD_TESTS=0                                                                 ^
-    -DBUILD_DOCS=0                                                                  ^
-    -DBUILD_PERF_TESTS=0                                                            ^
-    -DBUILD_ZLIB=0                                                                  ^
-    -DBUILD_PNG=0                                                                   ^
-    -DBUILD_JPEG=0                                                                  ^
-    -DBUILD_TIFF=0                                                                  ^
-    -DBUILD_WEBP=0                                                                  ^
-    -DBUILD_OPENJPEG=0                                                              ^
-    -DBUILD_JASPER=0                                                                ^
-    -DBUILD_OPENEXR=0                                                               ^
-    -DWITH_PNG=ON                                                                   ^
-    -DWITH_JPEG=ON                                                                  ^
-    -DWITH_TIFF=ON                                                                  ^
-    -DWITH_WEBP=ON                                                                  ^
-    -DWEBP_LIBRARY=%PREFIX%/Library/lib/libwebp.lib                                 ^
-    -DWEBP_INCLUDE_DIR=%PREFIX%/Library/include                                     ^
-    -DWITH_OPENJPEG=ON                                                              ^
-    -DWITH_JASPER=OFF                                                               ^
-    -DWITH_OPENEXR=ON                                                               ^
-    -DWITH_PROTOBUF=1                                                               ^
-    -DBUILD_PROTOBUF=0                                                              ^
-    -DPROTOBUF_UPDATE_FILES=1                                                       ^
-    -DBUILD_opencv_bioinspired=0                                                    ^
-    -DWITH_CUDA=0                                                                   ^
-    -DWITH_CUBLAS=0                                                                 ^
-    -DWITH_OPENCL=0                                                                 ^
-    -DWITH_OPENCLAMDFFT=0                                                           ^
-    -DWITH_OPENCLAMDBLAS=0                                                          ^
-    -DWITH_OPENCL_D3D11_NV=0                                                        ^
-    -DWITH_OPENVINO=0                                                               ^
-    -DWITH_1394=0                                                                   ^
-    -DWITH_OPENNI=0                                                                 ^
-    -DWITH_HDF5=1                                                                   ^
-    -DWITH_FFMPEG=0                                                                 ^
-    -DWITH_TENGINE=0                                                                ^
-    -DWITH_GSTREAMER=1                                                              ^
-    -DWITH_MATLAB=0                                                                 ^
-    -DWITH_TESSERACT=0                                                              ^
-    -DWITH_VA=0                                                                     ^
-    -DWITH_VA_INTEL=0                                                               ^
-    -DWITH_VTK=0                                                                    ^
-    -DWITH_GTK=0                                                                    ^
-    -DWITH_QT=%QT%                                                          ^
-    -DWITH_GPHOTO2=0                                                                ^
-    -DWITH_WIN32UI=0                                                                ^
-    -DINSTALL_C_EXAMPLES=0                                                          ^
-    -DOPENCV_EXTRA_MODULES_PATH=%UNIX_SRC_DIR%/opencv_contrib/modules               ^
-    -DPYTHON_EXECUTABLE=%UNIX_PREFIX%/python                                        ^
-    -DPYTHON_INCLUDE_PATH=%UNIX_PREFIX%/include                                     ^
-    -DPYTHON_PACKAGES_PATH=%UNIX_SP_DIR%                                            ^
-    -DPYTHON_LIBRARY=%UNIX_PREFIX%/libs/%PY_LIB%                                    ^
-    -DOPENCV_SKIP_PYTHON_LOADER=1                                                   ^
-    -DBUILD_opencv_python2=0                                                        ^
-    -DPYTHON2_EXECUTABLE=""                                                         ^
-    -DPYTHON2_INCLUDE_DIR=""                                                        ^
-    -DPYTHON2_NUMPY_INCLUDE_DIRS=""                                                 ^
-    -DPYTHON2_LIBRARY=""                                                            ^
-    -DPYTHON2_PACKAGES_PATH=""                                                      ^
-    -DOPENCV_PYTHON2_INSTALL_PATH=""                                                ^
-    -DBUILD_opencv_python3=1                                                        ^
-    -DPYTHON3_EXECUTABLE=%UNIX_PREFIX%/python                                       ^
-    -DPYTHON3_INCLUDE_PATH=%UNIX_PREFIX%/include                                    ^
-    -DPYTHON3_LIBRARY=%UNIX_PREFIX%/libs/%PY_LIB%                                   ^
-    -DPYTHON3_PACKAGES_PATH=%UNIX_SP_DIR%                                           ^
-    -DOPENCV_PYTHON3_INSTALL_PATH=%UNIX_SP_DIR%                                     ^
-    -DOPENCV_PYTHON_PIP_METADATA_INSTALL=ON                                         ^
-    -DOPENCV_PYTHON_PIP_METADATA_INSTALLER:STRING="conda"                           ^
-    ..
+
+cmake -LAH -B build -G "Ninja" -S .                                          ^
+    -DCMAKE_BUILD_TYPE="Release"                                             ^
+    -DCMAKE_INSTALL_PREFIX=%UNIX_LIBRARY_PREFIX%                             ^
+    -DCMAKE_PREFIX_PATH=%UNIX_LIBRARY_PREFIX%                                ^
+    -DOPENCV_CONFIG_INSTALL_PATH=cmake                                       ^
+    -DOPENCV_BIN_INSTALL_PATH=bin                                            ^
+    -DOPENCV_LIB_INSTALL_PATH=lib                                            ^
+    -DOPENCV_GENERATE_SETUPVARS=OFF                                          ^
+    -DOPENCV_DOWNLOAD_TRIES=1;2;3;4;5                                        ^
+    -DOPENCV_DOWNLOAD_PARAMS=INACTIVITY_TIMEOUT;30;TIMEOUT;180;SHOW_PROGRESS ^
+    -DOPENCV_GENERATE_PKGCONFIG=OFF                                          ^
+    -DENABLE_CONFIG_VERIFICATION=ON                                          ^
+    -DENABLE_PRECOMPILED_HEADERS=OFF                                         ^
+    -DWITH_LAPACK=0                                                          ^
+    -DCMAKE_CXX_STANDARD=17                                                  ^
+    -DWITH_AVIF=1                                                            ^
+    -DWITH_EIGEN=1                                                           ^
+    -DBUILD_TESTS=0                                                          ^
+    -DBUILD_DOCS=0                                                           ^
+    -DBUILD_PERF_TESTS=0                                                     ^
+    -DBUILD_ZLIB=0                                                           ^
+    -DBUILD_PNG=0                                                            ^
+    -DBUILD_JPEG=0                                                           ^
+    -DBUILD_TIFF=0                                                           ^
+    -DBUILD_WEBP=0                                                           ^
+    -DBUILD_OPENJPEG=0                                                       ^
+    -DBUILD_JASPER=0                                                         ^
+    -DBUILD_OPENEXR=0                                                        ^
+    -DWITH_PNG=ON                                                            ^
+    -DWITH_JPEG=ON                                                           ^
+    -DWITH_TIFF=ON                                                           ^
+    -DWITH_WEBP=ON                                                           ^
+    -DWEBP_LIBRARY=%PREFIX%/Library/lib/libwebp.lib                          ^
+    -DWEBP_INCLUDE_DIR=%PREFIX%/Library/include                              ^
+    -DWITH_OPENJPEG=ON                                                       ^
+    -DWITH_JASPER=0                                                          ^
+    -DWITH_OPENEXR=ON                                                        ^
+    -DWITH_PROTOBUF=1                                                        ^
+    -DBUILD_PROTOBUF=0                                                       ^
+    -DPROTOBUF_UPDATE_FILES=1                                                ^
+    -DBUILD_opencv_bioinspired=0                                             ^
+    -DWITH_CUDA=0                                                            ^
+    -DWITH_CUBLAS=0                                                          ^
+    -DWITH_OPENCL=0                                                          ^
+    -DWITH_OPENCLAMDFFT=0                                                    ^
+    -DWITH_OPENCLAMDBLAS=0                                                   ^
+    -DWITH_OPENCL_D3D11_NV=0                                                 ^
+    -DWITH_OPENVINO=0                                                        ^
+    -DWITH_1394=0                                                            ^
+    -DWITH_OPENNI=0                                                          ^
+    -DWITH_HDF5=1                                                            ^
+    -DWITH_FFMPEG=1                                                          ^
+    -DWITH_TENGINE=0                                                         ^
+    -DWITH_GSTREAMER=0                                                       ^
+    -DWITH_MATLAB=0                                                          ^
+    -DWITH_TESSERACT=0                                                       ^
+    -DWITH_VA=0                                                              ^
+    -DWITH_VA_INTEL=0                                                        ^
+    -DWITH_VTK=0                                                             ^
+    -DWITH_GTK=0                                                             ^
+    -DWITH_QT=%QT%                                                           ^
+    -DQT_SKIP_DEFAULT_TESTCASE_DIRS=0                                        ^
+    -DWITH_GPHOTO2=0                                                         ^
+    -DWITH_WIN32UI=0                                                         ^
+    -DWITH_OBSENSOR=0                                                        ^
+    -DINSTALL_C_EXAMPLES=0                                                   ^
+    -DOPENCV_EXTRA_MODULES_PATH=%UNIX_SRC_DIR%/opencv_contrib/modules        ^
+    -DPYTHON_EXECUTABLE=%UNIX_PREFIX%/python                                 ^
+    -DPYTHON_INCLUDE_PATH=%UNIX_PREFIX%/include                              ^
+    -DPYTHON_PACKAGES_PATH=%UNIX_SP_DIR%                                     ^
+    -DPYTHON_LIBRARY=%UNIX_PREFIX%/libs/%PY_LIB%                             ^
+    -DOPENCV_SKIP_PYTHON_LOADER=1                                            ^
+    -DBUILD_opencv_python2=0                                                 ^
+    -DPYTHON2_EXECUTABLE=""                                                  ^
+    -DPYTHON2_INCLUDE_DIR=""                                                 ^
+    -DPYTHON2_NUMPY_INCLUDE_DIRS=""                                          ^
+    -DPYTHON2_LIBRARY=""                                                     ^
+    -DPYTHON2_PACKAGES_PATH=""                                               ^
+    -DOPENCV_PYTHON2_INSTALL_PATH=""                                         ^
+    -DBUILD_opencv_python3=1                                                 ^
+    -DPYTHON3_EXECUTABLE=%UNIX_PREFIX%/python                                ^
+    -DPYTHON3_INCLUDE_PATH=%UNIX_PREFIX%/include                             ^
+    -DPYTHON3_LIBRARY=%UNIX_PREFIX%/libs/%PY_LIB%                            ^
+    -DPYTHON3_PACKAGES_PATH=%UNIX_SP_DIR%                                    ^
+    -DOPENCV_PYTHON3_INSTALL_PATH=%UNIX_SP_DIR%                              ^
+    -DOPENCV_PYTHON_PIP_METADATA_INSTALL=ON                                  ^
+    -DOPENCV_PYTHON_PIP_METADATA_INSTALLER:STRING="conda"
 if %ERRORLEVEL% neq 0 (type CMakeError.log && exit 1)
 
-cmake --build . --target install --config Release
+cmake --build build --target install --config Release
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -12,6 +12,9 @@ if [[ "${target_platform}" == linux-* ]]; then
     # with GCC opencv/issues/8097
     export CXXFLAGS="$CXXFLAGS -D__STDC_CONSTANT_MACROS"
     OPENMP="-DWITH_OPENMP=1"
+elif [[ "${target_platform}" == osx-* ]]; then
+    CMAKE_ARGS="${CMAKE_ARGS} -D_LIBCPP_DISABLE_AVAILABILITY=ON -DOPENCV_SKIP_LINK_NO_UNDEFINED=ON -DOPENCV_SKIP_LINK_AS_NEEDED=ON -DCPU_BASELINE_DISABLE=NEON_BF16"
+    V4L="0"
 fi
 
 if [[ "$build_variant" == "normal" ]]; then
@@ -20,10 +23,10 @@ else
     echo "Building headless variant without Qt"
 fi
 
-if [[ "${target_platform}" == osx-* ]]; then
-    V4L="0"
-elif [[ "${target_platform}" == linux-ppc64le ]]; then
-    OPENVINO="0"
+if [[ "$QT" == "6" ]]; then
+    # https://github.com/conda-forge/qt-main-feedstock/issues/332
+    sed -i.bak '/INTERFACE_COMPILE_DEFINITIONS/d' "${PREFIX}/lib/cmake/Qt6Test/Qt6TestTargets.cmake"
+    rm "${PREFIX}/lib/cmake/Qt6Test/Qt6TestTargets.cmake.bak"
 fi
 
 if [[ "${target_platform}" != "${build_platform}" ]]; then
@@ -45,9 +48,6 @@ fi
 # FFMPEG building requires pkgconfig
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
 
-mkdir -p build${PY_VER}
-cd build${PY_VER}
-
 # Note that though a dependency may be installed it may not be detected
 # correctly by this build system and so some functionality may be disabled
 # (this is more frequent on Windows but does sometimes happen on other OSes).
@@ -66,99 +66,102 @@ cd build${PY_VER}
 # We may want to revisit that in a future update.
 # The OPENCV_DOWNLOAD flags are there to make these downloads more robust.
 
-cmake -LAH -G "Ninja"                                                     \
-    ${CMAKE_ARGS}                                                         \
-    -DCMAKE_BUILD_TYPE="Release"                                          \
-    -DCMAKE_PREFIX_PATH=${PREFIX}                                         \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX}                                      \
-    -DCMAKE_INSTALL_LIBDIR="lib"                                          \
-    -DOPENCV_DOWNLOAD_TRIES=1\;2\;3\;4\;5                                 \
-    -DOPENCV_DOWNLOAD_PARAMS=INACTIVITY_TIMEOUT\;30\;TIMEOUT\;180\;SHOW_PROGRESS \
-    -DOPENCV_GENERATE_PKGCONFIG=ON                                        \
-    -DENABLE_CONFIG_VERIFICATION=ON                                       \
-    -DENABLE_PRECOMPILED_HEADERS=OFF                                      \
-    $OPENMP                                                               \
-    -DWITH_LAPACK=0                                                       \
-    -DCMAKE_CXX_STANDARD=17                                               \
-    -DWITH_EIGEN=1                                                        \
-    -DBUILD_TESTS=0                                                       \
-    -DBUILD_DOCS=0                                                        \
-    -DBUILD_PERF_TESTS=0                                                  \
-    -DBUILD_ZLIB=0                                                        \
-    -DBUILD_PNG=0                                                         \
-    -DBUILD_JPEG=0                                                        \
-    -DBUILD_TIFF=0                                                        \
-    -DBUILD_WEBP=0                                                        \
-    -DBUILD_OPENJPEG=0                                                    \
-    -DBUILD_JASPER=0                                                      \
-    -DBUILD_OPENEXR=0                                                     \
-    -DWITH_PNG=ON                                                         \
-    -DWITH_JPEG=ON                                                        \
-    -DWITH_TIFF=ON                                                        \
-    -DWITH_WEBP=ON                                                        \
-    -DWITH_OPENJPEG=ON                                                    \
-    -DWITH_JASPER=OFF                                                     \
-    -DWITH_OPENEXR=ON                                                     \
-    -DWITH_PROTOBUF=1                                                     \
-    -DBUILD_PROTOBUF=0                                                    \
-    -DPROTOBUF_UPDATE_FILES=1                                             \
-    -DWITH_V4L=$V4L                                                       \
-    -DWITH_CUDA=0                                                         \
-    -DWITH_CUBLAS=0                                                       \
-    -DWITH_OPENCL=0                                                       \
-    -DWITH_OPENCLAMDFFT=0                                                 \
-    -DWITH_OPENCLAMDBLAS=0                                                \
-    -DWITH_OPENCL_D3D11_NV=0                                              \
-    -DWITH_OPENVINO=0                                                     \
-    -DWITH_1394=0                                                         \
-    -DWITH_OPENNI=0                                                       \
-    -DWITH_HDF5=1                                                         \
-    -DWITH_FFMPEG=1                                                       \
-    -DWITH_TENGINE=0                                                      \
-    -DWITH_GSTREAMER=1                                                    \
-    -DWITH_MATLAB=0                                                       \
-    -DWITH_TESSERACT=0                                                    \
-    -DWITH_VA=0                                                           \
-    -DWITH_VA_INTEL=0                                                     \
-    -DWITH_VTK=0                                                          \
-    -DWITH_GTK=0                                                          \
-    -DWITH_QT=$QT                                                         \
-    -DWITH_OPENGL=ON                                                      \
-    -DWITH_GPHOTO2=0                                                      \
-    -DINSTALL_C_EXAMPLES=0                                                \
-    -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib/modules"               \
-    -DOpenCV_INSTALL_BINARIES_PREFIX=""                                   \
-    -DCMAKE_SKIP_RPATH:bool=ON                                            \
-    -DPYTHON_PACKAGES_PATH=${SP_DIR}                                      \
-    -DPYTHON_EXECUTABLE=${PYTHON}                                         \
-    -DPYTHON_INCLUDE_PATH=${INC_PYTHON}                                   \
-    -DOPENCV_SKIP_PYTHON_LOADER=1                                         \
-    -DZLIB_INCLUDE_DIR=${PREFIX}/include                                  \
-    -DPYTHON_LIBRARY=${LIB_PYTHON}                                        \
-    -DZLIB_LIBRARY_RELEASE=${PREFIX}/lib/libz${SHLIB_EXT}                 \
-    -DJPEG_INCLUDE_DIR=${PREFIX}/include                                  \
-    -DTIFF_INCLUDE_DIR=${PREFIX}/include                                  \
-    -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include                               \
-    -DPROTOBUF_INCLUDE_DIR=${PREFIX}/include                              \
-    -DPROTOBUF_LIBRARIES=${PREFIX}/lib                                    \
-    -DOPENCV_ENABLE_PKG_CONFIG=1                                          \
-    -DOPENCV_PYTHON_PIP_METADATA_INSTALL=ON                               \
-    -DOPENCV_PYTHON_PIP_METADATA_INSTALLER:STRING="conda"                 \
-    -DBUILD_opencv_python3=1                                              \
-    -DPYTHON3_EXECUTABLE=${PYTHON}                                        \
-    -DPYTHON3_INCLUDE_PATH=${INC_PYTHON}                                    \
-    -DPYTHON3_NUMPY_INCLUDE_DIRS=$(python -c 'import numpy;print(numpy.get_include())')  \
-    -DPYTHON3_LIBRARY=${LIB_PYTHON}                                       \
-    -DPYTHON_DEFAULT_EXECUTABLE=${PREFIX}/bin/python                      \
-    -DPYTHON3_PACKAGES_PATH=${SP_DIR}                                     \
-    -DOPENCV_PYTHON3_INSTALL_PATH=${SP_DIR}                               \
-    -DBUILD_opencv_python2=0                                              \
-    -DPYTHON2_EXECUTABLE=                                                 \
-    -DPYTHON2_INCLUDE_DIR=                                                \
-    -DPYTHON2_NUMPY_INCLUDE_DIRS=                                         \
-    -DPYTHON2_LIBRARY=                                                    \
-    -DPYTHON2_PACKAGES_PATH=                                              \
-    -DOPENCV_PYTHON2_INSTALL_PATH=                                        \
-    ..
+cmake -LAH -B build -G "Ninja" -S .                                                     \
+    ${CMAKE_ARGS}                                                                       \
+    -DCMAKE_BUILD_TYPE="Release"                                                        \
+    -DCMAKE_PREFIX_PATH=${PREFIX}                                                       \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX}                                                    \
+    -DCMAKE_INSTALL_LIBDIR="lib"                                                        \
+    -DOPENCV_DOWNLOAD_TRIES=1\;2\;3\;4\;5                                               \
+    -DOPENCV_DOWNLOAD_PARAMS=INACTIVITY_TIMEOUT\;30\;TIMEOUT\;180\;SHOW_PROGRESS        \
+    -DOPENCV_GENERATE_PKGCONFIG=ON                                                      \
+    -DENABLE_CONFIG_VERIFICATION=ON                                                     \
+    -DENABLE_PRECOMPILED_HEADERS=OFF                                                    \
+    ${OPENMP}                                                                           \
+    -DWITH_LAPACK=0                                                                     \
+    -DCMAKE_CXX_STANDARD=17                                                             \
+    -DWITH_AVIF=1                                                                       \
+    -DWITH_EIGEN=1                                                                      \
+    -DBUILD_TESTS=0                                                                     \
+    -DBUILD_DOCS=0                                                                      \
+    -DBUILD_PERF_TESTS=0                                                                \
+    -DBUILD_ZLIB=0                                                                      \
+    -DBUILD_PNG=0                                                                       \
+    -DBUILD_JPEG=0                                                                      \
+    -DBUILD_TIFF=0                                                                      \
+    -DBUILD_WEBP=0                                                                      \
+    -DBUILD_OPENJPEG=0                                                                  \
+    -DBUILD_JASPER=0                                                                    \
+    -DBUILD_OPENEXR=0                                                                   \
+    -DWITH_PNG=ON                                                                       \
+    -DWITH_JPEG=ON                                                                      \
+    -DWITH_TIFF=ON                                                                      \
+    -DWITH_WEBP=ON                                                                      \
+    -DWITH_OPENJPEG=ON                                                                  \
+    -DWITH_JASPER=0                                                                     \
+    -DWITH_OPENEXR=ON                                                                   \
+    -DWITH_PROTOBUF=1                                                                   \
+    -DBUILD_PROTOBUF=0                                                                  \
+    -DPROTOBUF_UPDATE_FILES=1                                                           \
+    -DWITH_V4L=$V4L                                                                     \
+    -DWITH_CUDA=0                                                                       \
+    -DWITH_CUBLAS=0                                                                     \
+    -DWITH_OPENCL=0                                                                     \
+    -DWITH_OPENCLAMDFFT=0                                                               \
+    -DWITH_OPENCLAMDBLAS=0                                                              \
+    -DWITH_OPENCL_D3D11_NV=0                                                            \
+    -DWITH_OPENVINO=0                                                                   \
+    -DWITH_1394=0                                                                       \
+    -DWITH_OPENNI=0                                                                     \
+    -DWITH_HDF5=1                                                                       \
+    -DWITH_FFMPEG=1                                                                     \
+    -DWITH_TENGINE=0                                                                    \
+    -DWITH_GSTREAMER=0                                                                  \
+    -DWITH_MATLAB=0                                                                     \
+    -DWITH_TESSERACT=0                                                                  \
+    -DWITH_VA=0                                                                         \
+    -DWITH_VA_INTEL=0                                                                   \
+    -DWITH_VTK=0                                                                        \
+    -DWITH_GTK=0                                                                        \
+    -DWITH_QT=$QT                                                                       \
+    -DQT_SKIP_DEFAULT_TESTCASE_DIRS=0                                                   \
+    -DWITH_QTTEST=OFF                                                                   \
+    -DWITH_OPENGL=ON                                                                    \
+    -DWITH_GPHOTO2=0                                                                    \
+    -DWITH_OBSENSOR=0                                                                   \
+    -DINSTALL_C_EXAMPLES=0                                                              \
+    -DOPENCV_EXTRA_MODULES_PATH="${SRC_DIR}/opencv_contrib/modules"                     \
+    -DOpenCV_INSTALL_BINARIES_PREFIX=""                                                 \
+    -DCMAKE_SKIP_RPATH:bool=ON                                                          \
+    -DPYTHON_PACKAGES_PATH=${SP_DIR}                                                    \
+    -DPYTHON_EXECUTABLE=${PYTHON}                                                       \
+    -DPYTHON_INCLUDE_PATH=${INC_PYTHON}                                                 \
+    -DOPENCV_SKIP_PYTHON_LOADER=1                                                       \
+    -DZLIB_INCLUDE_DIR=${PREFIX}/include                                                \
+    -DPYTHON_LIBRARY=${LIB_PYTHON}                                                      \
+    -DZLIB_LIBRARY_RELEASE=${PREFIX}/lib/libz${SHLIB_EXT}                               \
+    -DJPEG_INCLUDE_DIR=${PREFIX}/include                                                \
+    -DTIFF_INCLUDE_DIR=${PREFIX}/include                                                \
+    -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include                                             \
+    -DPROTOBUF_INCLUDE_DIR=${PREFIX}/include                                            \
+    -DPROTOBUF_LIBRARIES=${PREFIX}/lib                                                  \
+    -DOPENCV_ENABLE_PKG_CONFIG=1                                                        \
+    -DOPENCV_PYTHON_PIP_METADATA_INSTALL=ON                                             \
+    -DOPENCV_PYTHON_PIP_METADATA_INSTALLER:STRING="conda"                               \
+    -DBUILD_opencv_python3=1                                                            \
+    -DPYTHON3_EXECUTABLE=${PYTHON}                                                      \
+    -DPYTHON3_INCLUDE_PATH=${INC_PYTHON}                                                \
+    -DPYTHON3_NUMPY_INCLUDE_DIRS=$(python -c 'import numpy;print(numpy.get_include())') \
+    -DPYTHON3_LIBRARY=${LIB_PYTHON}                                                     \
+    -DPYTHON_DEFAULT_EXECUTABLE=${PREFIX}/bin/python                                    \
+    -DPYTHON3_PACKAGES_PATH=${SP_DIR}                                                   \
+    -DOPENCV_PYTHON3_INSTALL_PATH=${SP_DIR}                                             \
+    -DBUILD_opencv_python2=0                                                            \
+    -DPYTHON2_EXECUTABLE=                                                               \
+    -DPYTHON2_INCLUDE_DIR=                                                              \
+    -DPYTHON2_NUMPY_INCLUDE_DIRS=                                                       \
+    -DPYTHON2_LIBRARY=                                                                  \
+    -DPYTHON2_PACKAGES_PATH=                                                            \
+    -DOPENCV_PYTHON2_INSTALL_PATH=                                                      
 
-ninja install -j${CPU_COUNT}
+cmake --build build --target install -j${CPU_COUNT}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,11 @@
+# https://doc.qt.io/qt-6/windows.html
+c_compiler:        # [win]
+  - vs2022         # [win]
+cxx_compiler:      # [win]
+  - vs2022         # [win]
+c_stdlib_version:  # [win]
+  - 2022.12        # [win]
+
 build_variant:
   - normal
   # As of 5/30/2022 headless is only to be available on the sfe1ed40 channel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@
 #
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
-{% set version = "4.10.0" %}
-{% set build_num = "7" %}
+{% set version = "4.12.0" %}
+{% set build_num = "0" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
@@ -28,35 +28,27 @@ package:
 
 source:
   - url: https://github.com/opencv/opencv/archive/{{ version }}.tar.gz
-    fn: opencv-{{ version }}.tar.gz
-    sha256: b2171af5be6b26f7a06b1229948bbb2bdaa74fcf5cd097e0af6378fce50a6eb9
+    sha256: 44c106d5bb47efec04e531fd93008b3fcd1d27138985c5baf4eafac0e1ec9e9d
     patches:
       # backport https://github.com/opencv/opencv/pull/21611 (unmerged as of 06/2023)
+      - patches_opencv/0001-fix-operator-warnings-and-redundant-parameter.patch  # [win]
       - patches_opencv/0001-Add-installation-of-pip-metadata-from-cmake.patch
       - patches_opencv/0001-Also-install-metadata-for-opencv-python-headless.patch
       - patches_opencv/0002-delete-lines-that-download-opencv.patch
       - patches_opencv/0003-find-pkgconfig-on-windows.patch
       - patches_opencv/0004-fix-detection-for-protobuf-23.x.patch
+      - patches_opencv/0005-patch-qt6.patch
   - url: https://github.com/opencv/opencv_contrib/archive/{{ version }}.tar.gz
-    fn: opencv_contrib-{{ version }}.tar.gz
-    sha256: 65597f8fb8dc2b876c1b45b928bbcc5f772ddbaf97539bf1b737623d0604cba1
+    sha256: 4197722b4c5ed42b476d42e29beb29a52b6b25c34ec7b4d589c3ae5145fee98e
     folder: opencv_contrib
     patches:
       # Allow attempt to find HDF5 on cross-compile
       - patches_opencv_contrib/cmake_hdf5_xpile.patch
-  - fn: test.avi
-    url: https://github.com/opencv/opencv_extra/raw/master/testdata/highgui/video/VID00003-20100701-2204.avi
+  - url: https://github.com/opencv/opencv_extra/raw/master/testdata/highgui/video/VID00003-20100701-2204.avi
     sha256: 78884f64b564a3b06dc6ee731ed33b60c6d8cd864cea07f21d94ba0f90c7b310
 
 build:
   number: {{ build_num }}
-  # qtbase isn't available for osx-64
-  skip: True  # [osx and x86_64]
-
-requirements:
-  build:
-    - m2-patch  # [win]
-    - patch     # [unix]
 
 outputs:
   - name: {{ package_name }}
@@ -89,14 +81,15 @@ outputs:
         - cmake
         - ninja-base
         # pkg-config on win pulls in python
-        - python                        # [win]
+        - python  # [win]
       host:
         - python
         - eigen 3.4.0
-        - ffmpeg {{ ffmpeg }}           # [not win]
+        - ffmpeg {{ ffmpeg }}
         - freetype {{ freetype }}
         - gst-plugins-base {{ gst_plugins_base }}
         - gstreamer {{ gstreamer }}
+        - libavif {{ libavif }}
         # harfbuzz, glib, gettext are both needed for freetype support
         - harfbuzz {{ harfbuzz }}
         - hdf5 {{ hdf5 }}
@@ -112,7 +105,7 @@ outputs:
         - libtiff {{ libtiff }}
         - libwebp-base {{ libwebp }}
         - numpy {{ numpy }}
-        - openjpeg {{ openjpeg }}
+        - libopenjpeg {{ openjpeg }}
         - qtbase-devel {{ qt }}  # [build_variant == "normal"]
         - qt5compat              # [build_variant == "normal"]
         - libgl-devel {{ libgl }}  # [linux]
@@ -131,7 +124,7 @@ outputs:
         - gstreamer
         - hdf5
         - jpeg            # [not win]
-        - openjpeg
+        - libopenjpeg
         - libiconv        # [unix]
         - libpng
         - libprotobuf
@@ -143,13 +136,13 @@ outputs:
 
     test:
         source_files:
-          - test.avi
+          - VID00003-20100701-2204.avi
         requires:
           - {{ compiler('c') }}
           - {{ compiler('cxx') }}
           - pkg-config                     # [not win]
           - cmake
-          - ninja
+          - ninja-base
           - pip
         files:
           - CMakeLists.txt
@@ -295,14 +288,14 @@ outputs:
   {% endif %}
 
 about:
-  home: https://opencv.org/
+  home: https://opencv.org
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: Computer vision and machine learning software library.
   description: Computer vision and machine learning software library.
   dev_url: https://github.com/opencv/opencv
-  doc_url: https://docs.opencv.org/{{ major_version }}.x/
+  doc_url: https://docs.opencv.org/{{ major_version }}.x
 
 extra:
   skip-lints:

--- a/recipe/patches_opencv/0001-fix-operator-warnings-and-redundant-parameter.patch
+++ b/recipe/patches_opencv/0001-fix-operator-warnings-and-redundant-parameter.patch
@@ -1,0 +1,60 @@
+From 14a4036af2f87e46166d81fece9c81a6d785a08e Mon Sep 17 00:00:00 2001
+From: Ivan Iziumov <iiziumov@anaconda.com>
+Date: Wed, 8 Oct 2025 15:58:42 +0200
+Subject: [PATCH] fix opertaor warnings and redundant parameter
+
+---
+ modules/highgui/src/window_QT.cpp |  3 ---
+ modules/highgui/src/window_QT.h   | 22 +++++++++++-----------
+ 2 files changed, 11 insertions(+), 14 deletions(-)
+
+diff --git a/modules/highgui/src/window_QT.cpp b/modules/highgui/src/window_QT.cpp
+index fa8c5d7801..fe6771c292 100644
+--- a/modules/highgui/src/window_QT.cpp
++++ b/modules/highgui/src/window_QT.cpp
+@@ -529,9 +529,6 @@ static int icvInitSystem(int* c, char** v)
+     //"For any GUI application using Qt, there is precisely one QApplication object"
+     if (!QApplication::instance())
+     {
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+-        QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+-#endif
+         new QApplication(*c, v);
+         setlocale(LC_NUMERIC,"C");
+ 
+diff --git a/modules/highgui/src/window_QT.h b/modules/highgui/src/window_QT.h
+index 1224ba9d32..99d8bf2f8a 100644
+--- a/modules/highgui/src/window_QT.h
++++ b/modules/highgui/src/window_QT.h
+@@ -96,17 +96,17 @@
+ enum { CV_MODE_NORMAL = 0, CV_MODE_OPENGL = 1 };
+ 
+ //we can change the keyboard shortcuts from here !
+-enum {	shortcut_zoom_normal 	= Qt::CTRL + Qt::Key_Z,
+-        shortcut_zoom_imgRegion = Qt::CTRL + Qt::Key_X,
+-        shortcut_save_img		= Qt::CTRL + Qt::Key_S,
+-        shortcut_copy_clipbrd   = Qt::CTRL + Qt::Key_C,
+-        shortcut_properties_win	= Qt::CTRL + Qt::Key_P,
+-        shortcut_zoom_in 		= Qt::CTRL + Qt::Key_Plus,//QKeySequence(QKeySequence::ZoomIn),
+-        shortcut_zoom_out		= Qt::CTRL + Qt::Key_Minus,//QKeySequence(QKeySequence::ZoomOut),
+-        shortcut_panning_left 	= Qt::CTRL + Qt::Key_Left,
+-        shortcut_panning_right 	= Qt::CTRL + Qt::Key_Right,
+-        shortcut_panning_up 	= Qt::CTRL + Qt::Key_Up,
+-        shortcut_panning_down 	= Qt::CTRL + Qt::Key_Down
++enum {	shortcut_zoom_normal 	= Qt::CTRL | Qt::Key_Z,
++        shortcut_zoom_imgRegion = Qt::CTRL | Qt::Key_X,
++        shortcut_save_img		= Qt::CTRL | Qt::Key_S,
++        shortcut_copy_clipbrd   = Qt::CTRL | Qt::Key_C,
++        shortcut_properties_win	= Qt::CTRL | Qt::Key_P,
++        shortcut_zoom_in 		= Qt::CTRL | Qt::Key_Plus,//QKeySequence(QKeySequence::ZoomIn),
++        shortcut_zoom_out		= Qt::CTRL | Qt::Key_Minus,//QKeySequence(QKeySequence::ZoomOut),
++        shortcut_panning_left 	= Qt::CTRL | Qt::Key_Left,
++        shortcut_panning_right 	= Qt::CTRL | Qt::Key_Right,
++        shortcut_panning_up 	= Qt::CTRL | Qt::Key_Up,
++        shortcut_panning_down 	= Qt::CTRL | Qt::Key_Down
+     };
+ //end enum
+ 
+-- 
+2.51.0
+

--- a/recipe/patches_opencv/0005-patch-qt6.patch
+++ b/recipe/patches_opencv/0005-patch-qt6.patch
@@ -1,0 +1,17 @@
+---
+ modules/highgui/CMakeLists.txt |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: modules/highgui/CMakeLists.txt
+===================================================================
+--- a/modules/highgui/CMakeLists.txt
++++ b/modules/highgui/CMakeLists.txt
+@@ -125,7 +125,7 @@ elseif(HAVE_QT)
+     endif()
+ 
+     foreach(dt_dep ${qt_deps})
+-      add_definitions(${Qt${QT_VERSION_MAJOR}${dt_dep}_DEFINITIONS})
++      link_libraries(${Qt${QT_VERSION_MAJOR}${dt_dep}})
+       include_directories(${Qt${QT_VERSION_MAJOR}${dt_dep}_INCLUDE_DIRS})
+       list(APPEND HIGHGUI_LIBRARIES ${Qt${QT_VERSION_MAJOR}${dt_dep}_LIBRARIES})
+     endforeach()


### PR DESCRIPTION
opencv 4.12.0

**Destination channel:** defaults

### Links

- [PKG-9735](https://anaconda.atlassian.net/browse/PKG-9735)
- dev_url:        https://github.com/opencv/opencv/tree/4.12.0
- conda_forge:    https://github.com/conda-forge/opencv-feedstock
- pypi:           https://pypi.org/project/opencv-python/4.12.0.88
- pypi inspector: https://inspector.pypi.io/project/opencv-python/4.12.0.88

### Explanation of changes:

- new version
- Added patches to highgui and QT6, to remove redundant warnings and errors preventing the build 
- WITH_OBSENSOR=OFF was added, as we don't have the appropriate module
- Switched to libopenjpeg as it is the new approach in our registry
- Specified 2022 version of VS compilers and stdlib to enable proper QT6 build on Windows


[PKG-9735]: https://anaconda.atlassian.net/browse/PKG-9735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ