### PR TITLE
opencv/opencv-python-headless 4.13.0 (build 3)

### DIFF
--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -128,7 +128,7 @@ cmake -LAH -B build -G "Ninja" -S .                                             
     -DWITH_QT=$QT                                                                       \
     -DQT_SKIP_DEFAULT_TESTCASE_DIRS=0                                                   \
     -DWITH_QTTEST=OFF                                                                   \
-    -DWITH_OPENGL=ON                                                                    \
+    -DWITH_OPENGL=${USE_OPENGL}                                                         \
     -DWITH_GPHOTO2=0                                                                    \
     -DWITH_OBSENSOR=0                                                                   \
     -DINSTALL_C_EXAMPLES=0                                                              \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,4 +9,4 @@ c_stdlib_version:  # [win]
 build_variant:
   - normal
   # As of 5/30/2022 headless is only to be available on the sfe1ed40 channel
-  # - headless
+  - headless

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,9 +10,4 @@ build_variant:
   - normal
   - headless
 
-libabseil:
-  - 20250814.1
-libprotobuf:
-  - 6.33.0
-
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,5 +8,11 @@ c_stdlib_version:  # [win]
 
 build_variant:
   - normal
-  # As of 5/30/2022 headless is only to be available on the sfe1ed40 channel
   - headless
+
+libabseil:
+  - 20250814.1
+libprotobuf:
+  - 6.33.0
+
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,6 @@ outputs:
         #
         - {{ pin_subpackage(package_name, max_pin='x.x') }} qt* # [build_variant == "normal"]
         - {{ pin_subpackage(package_name, max_pin='x.x') }} headless* # [build_variant == "headless"]
-        - {{ package_name }} >={{ version }}
     requirements:
       build:
         - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,11 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.13.0" %}
-{% set build_num = "2" %}
+# give higher priority to the qt variant
+{% set build_num = 2 %}
+{% if build_variant == "normal" %}
+{% set build_num = 100 + build_num %}
+{% endif %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
@@ -58,9 +62,6 @@ outputs:
         - QT=0                       # [build_variant == "headless"]
         - USE_OPENGL=ON              # [build_variant == "normal" and (linux)]
         - USE_OPENGL_OFF             # [build_variant == "headless" or not (linux)]
-      ignore_run_exports:
-        # qt5compat is needed for a CMake find_package() call but is not actually used in OpenCV anymore.
-        - qt5compat
     run_exports:
       # We are cautiously optimistic here that patch-level updates won't break
       # ABI. However, it sounds like upstream won't guarantee *any* sort of
@@ -114,7 +115,6 @@ outputs:
         - python
         - numpy
         # bounds set through run exports
-        - eigen
         - ffmpeg                # [not win]
         - freetype
         - harfbuzz
@@ -150,13 +150,7 @@ outputs:
           - run_py_test.py
           - color_palette_alpha.png
           - test_1_c1.jpg
-        script_env:
-          # The testing script_env should match the build script_env. 
-          # See: https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#use-environment-variables
-          - QT={{ qt.split(".")[0] }}  # [build_variant == "normal"]
-          - QT=0                       # [build_variant == "headless"]
-          - USE_OPENGL=ON              # [build_variant == "normal" and (linux)]
-          - USE_OPENGL_OFF             # [build_variant == "headless" or not (linux)]
+
         commands:
           # Verify pkg-config functionality
           - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig                        # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,7 @@
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
 
-# {% if build_variant == "headless" %}
-# {%   set package_name = "opencv-python-headless" %}
-# {% else %}
 {%   set package_name = "opencv" %}
-# {% endif %}
 
 package:
   name: opencv-suite
@@ -155,6 +151,10 @@ outputs:
           - color_palette_alpha.png
           - test_1_c1.jpg
         script_env:
+          # The testing script_env should match the build script_env. 
+          # See: https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#use-environment-variables
+          - QT={{ qt.split(".")[0] }}  # [build_variant == "normal"]
+          - QT=0                       # [build_variant == "headless"]
           - USE_OPENGL=ON              # [build_variant == "normal" and (linux)]
           - USE_OPENGL_OFF             # [build_variant == "headless" or not (linux)]
         commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.13.0" %}
 # give higher priority to the qt variant
-{% set build_num = 2 %}
+{% set build_num = 3 %}
 {% if build_variant == "normal" %}
 {% set build_num = 100 + build_num %}
 {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,16 +11,16 @@
 # By putting all the generated files in 1 package, this makes the build process
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.13.0" %}
-{% set build_num = "1" %}
+{% set build_num = "2" %}
 {% set major_version = version.split('.')[0] %}
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
 
-{% if build_variant == "headless" %}
-{%   set package_name = "opencv-python-headless" %}
-{% else %}
+# {% if build_variant == "headless" %}
+# {%   set package_name = "opencv-python-headless" %}
+# {% else %}
 {%   set package_name = "opencv" %}
-{% endif %}
+# {% endif %}
 
 package:
   name: opencv-suite
@@ -55,9 +55,13 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_num }}
+      string: qt{{ qt.replace('.', '') }}_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "normal"]
+      string: headless_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "headless"]
       script_env:
         - QT={{ qt.split(".")[0] }}  # [build_variant == "normal"]
         - QT=0                       # [build_variant == "headless"]
+        - USE_OPENGL=ON              # [build_variant == "normal" and (linux)]
+        - USE_OPENGL_OFF             # [build_variant == "headless" or not (linux)]
       ignore_run_exports:
         # qt5compat is needed for a CMake find_package() call but is not actually used in OpenCV anymore.
         - qt5compat
@@ -68,8 +72,9 @@ outputs:
       #
       #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
       #
-      - {{ pin_subpackage('opencv', max_pin='x.x') }} # [build_variant == 'normal']
-      - {{ pin_subpackage('opencv-python-headless', max_pin='x.x') }} # [build_variant == 'headless']
+      # - {{ pin_subpackage('opencv', max_pin='x.x') }} # [build_variant == 'normal']
+      # - {{ pin_subpackage('opencv-python-headless', max_pin='x.x') }} # [build_variant == 'headless']
+      - {{ pin_subpackage(package_name, exact=True) }}
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -151,6 +156,9 @@ outputs:
           - run_py_test.py
           - color_palette_alpha.png
           - test_1_c1.jpg
+        script_env:
+          - USE_OPENGL=ON              # [build_variant == "normal" and (linux)]
+          - USE_OPENGL_OFF             # [build_variant == "headless" or not (linux)]
         commands:
           # Verify pkg-config functionality
           - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig                        # [linux]
@@ -241,7 +249,7 @@ outputs:
           - test $(pip list | grep opencv-python | wc -l) -eq 2  # [unix]
           - test $(pip list | grep opencv-python-headless | wc -l) -eq 1  # [unix]
 
-  {% if build_variant == "normal" %}
+  #{% if build_variant == "normal" %}
   # This recipe has merged the outputs for the compiled libraries with the
   # python bindings that used to be vendored as libopencv and py-opencv. This
   # was done to try to improve maintainibility. The following two output
@@ -254,6 +262,8 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_num }}
+      string: qt{{ qt.replace('.', '') }}_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "normal"]
+      string: headless_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "headless"]
     run_exports:
       # We are cautiously optimistic here that patch-level updates won't break
       # ABI. However, it sounds like upstream won't guarantee *any* sort of
@@ -261,12 +271,12 @@ outputs:
       #
       #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
       #
-      - {{ pin_subpackage('libopencv', max_pin='x.x') }}
+      #- {{ pin_subpackage('libopencv', max_pin='x.x') }}
     requirements:
       host:
-        - {{ package_name }} =={{ version }}
+        - {{ pin_subpackage(package_name, exact=True) }}
       run:
-        - {{ package_name }} =={{ version }}
+        - {{ pin_subpackage(package_name, exact=True) }}
     test:
       commands:
         - echo "tested in other outputs"
@@ -277,15 +287,17 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_num }}
+      string: qt{{ qt.replace('.', '') }}_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "normal"]
+      string: headless_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "headless"]
     requirements:
       host:
-        - {{ package_name }} =={{ version }}
+        - {{ pin_subpackage(package_name, exact=True) }}
       run:
-        - {{ package_name }} =={{ version }}
+        - {{ pin_subpackage(package_name, exact=True) }}
     test:
       commands:
         - echo "tested in other outputs"
-  {% endif %}
+  #{% endif %}
 
 about:
   home: https://opencv.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ outputs:
       #
       #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
       #
-      - {{ pin_subpackage(package_name, exact=True) }}
+      - {{ pin_subpackage(package_name, max_pin='x.x') }}
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -262,7 +262,7 @@ outputs:
       #
       #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
       #
-      - {{ pin_subpackage('libopencv', exact=True) }}
+      - {{ pin_subpackage('libopencv', max_pin='x.x') }}
     requirements:
       host:
         - {{ pin_subpackage(package_name, exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,15 +61,20 @@ outputs:
         - QT={{ qt.split(".")[0] }}  # [build_variant == "normal"]
         - QT=0                       # [build_variant == "headless"]
         - USE_OPENGL=ON              # [build_variant == "normal" and (linux)]
-        - USE_OPENGL_OFF             # [build_variant == "headless" or not (linux)]
-    run_exports:
-      # We are cautiously optimistic here that patch-level updates won't break
-      # ABI. However, it sounds like upstream won't guarantee *any* sort of
-      # binary compatibility any longer. See also
-      #
-      #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
-      #
-      - {{ pin_subpackage(package_name, max_pin='x.x') }}
+        - USE_OPENGL=OFF             # [build_variant == "headless" or not (linux)]
+      ignore_run_exports:
+        # qt5compat is needed for a CMake find_package() call but is not actually used in OpenCV anymore.
+        - qt5compat
+      run_exports:
+        # We are cautiously optimistic here that patch-level updates won't break
+        # ABI. However, it sounds like upstream won't guarantee *any* sort of
+        # binary compatibility any longer. See also
+        #
+        #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
+        #
+        - {{ pin_subpackage(package_name, max_pin='x.x') }} qt* # [build_variant == "normal"]
+        - {{ pin_subpackage(package_name, max_pin='x.x') }} headless* # [build_variant == "headless"]
+        - {{ package_name }} >={{ version }}
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -255,14 +260,15 @@ outputs:
       number: {{ build_num }}
       string: qt{{ qt.replace('.', '') }}_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "normal"]
       string: headless_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "headless"]
-    run_exports:
-      # We are cautiously optimistic here that patch-level updates won't break
-      # ABI. However, it sounds like upstream won't guarantee *any* sort of
-      # binary compatibility any longer. See also
-      #
-      #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
-      #
-      - {{ pin_subpackage('libopencv', max_pin='x.x') }}
+      run_exports:
+        # We are cautiously optimistic here that patch-level updates won't break
+        # ABI. However, it sounds like upstream won't guarantee *any* sort of
+        # binary compatibility any longer. See also
+        #
+        #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
+        #
+        - {{ pin_subpackage('libopencv', max_pin='x.x') }} qt* # [build_variant == "normal"]
+        - {{ pin_subpackage('libopencv', max_pin='x.x') }} headless* # [build_variant == "headless"]
     requirements:
       host:
         - {{ pin_subpackage(package_name, exact=True) }}
@@ -280,6 +286,15 @@ outputs:
       number: {{ build_num }}
       string: qt{{ qt.replace('.', '') }}_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "normal"]
       string: headless_py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [build_variant == "headless"]
+      run_exports:
+        # We are cautiously optimistic here that patch-level updates won't break
+        # ABI. However, it sounds like upstream won't guarantee *any* sort of
+        # binary compatibility any longer. See also
+        #
+        #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
+        #
+        - {{ pin_subpackage('py-opencv', max_pin='x.x') }} qt* # [build_variant == "normal"]
+        - {{ pin_subpackage('py-opencv', max_pin='x.x') }} headless* # [build_variant == "headless"]
     requirements:
       host:
         - {{ pin_subpackage(package_name, exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,8 +72,6 @@ outputs:
       #
       #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
       #
-      # - {{ pin_subpackage('opencv', max_pin='x.x') }} # [build_variant == 'normal']
-      # - {{ pin_subpackage('opencv-python-headless', max_pin='x.x') }} # [build_variant == 'headless']
       - {{ pin_subpackage(package_name, exact=True) }}
     requirements:
       build:
@@ -249,7 +247,6 @@ outputs:
           - test $(pip list | grep opencv-python | wc -l) -eq 2  # [unix]
           - test $(pip list | grep opencv-python-headless | wc -l) -eq 1  # [unix]
 
-  #{% if build_variant == "normal" %}
   # This recipe has merged the outputs for the compiled libraries with the
   # python bindings that used to be vendored as libopencv and py-opencv. This
   # was done to try to improve maintainibility. The following two output
@@ -271,7 +268,7 @@ outputs:
       #
       #     https://github.com/opencv/opencv/wiki/OE-4.-OpenCV-4
       #
-      #- {{ pin_subpackage('libopencv', max_pin='x.x') }}
+      - {{ pin_subpackage('libopencv', exact=True) }}
     requirements:
       host:
         - {{ pin_subpackage(package_name, exact=True) }}
@@ -297,7 +294,6 @@ outputs:
     test:
       commands:
         - echo "tested in other outputs"
-  #{% endif %}
 
 about:
   home: https://opencv.org


### PR DESCRIPTION
opencv/opencv-python-headless 4.13.0 (build 3)

**Destination channel:** defaults

### Links

- [PKG-12565](https://anaconda.atlassian.net/browse/PKG-12565) 
- Upstream Repo: https://github.com/opencv/opencv
- Upstream Release Notes: https://github.com/opencv/opencv/releases
- Conda-Forge Repos: https://github.com/conda-forge/opencv-feedstock
- Relevant dependency PRs: 
  - Same changes, but built against an older version of libabseil: https://github.com/AnacondaRecipes/opencv-feedstock/pull/43


### Explanation of changes:

- Background: vLLM requires a headless version of opencv. This recipe previously only created headless packages for the Snowflake channel, but it was decided that it is acceptable to release them to the main channel. However, the naming should change to be opencv for both qt and headless versions and to use the build string to differentiate them. Additionally, in order to solve the dependencies for vLLM, an opencv build against a previous version of libabseil is required. The solution decided on was the make two builds of the newly modified opencv recipe. One build is built against an older libabseil will have a lower build number than the second build which will be built against the latest version of libabseil. This will preferentially select the version built against the latest libabseil if not otherwise specified.
- building headless versions of opencv
- differentiating headless and normal versions with the build string, similar to how Conda-Forge distributes the packages
- disabling OpenGL for headless builds
- building against latest version of libabseil
- build number is higher than the version built against older version of libabseil
- MERGE THIS AFTER PR #43 (https://github.com/AnacondaRecipes/opencv-feedstock/pull/43)

[PKG-12565]: https://anaconda.atlassian.net/browse/PKG-12565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ