### PR TITLE
rebuild-gstreamer-1.28.1-cve

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -11,13 +11,3 @@ build_variant:
   - headless
 
 
-# Temporary pin until the global gstreamer pin is updated.
-# OpenCV should be built against 1.28.1 specifically because this
-# release contains the CVE fixes we want to pick up.q
-gst_plugins_base:
-  - '1.28.1'
-
-gstreamer:
-  - '1.28.1'
-
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,10 +91,10 @@ outputs:
         # which is not reflected in cbc.yaml yet
         - ffmpeg {{ ffmpeg }}
         - freetype {{ freetype }}
-        - gst-plugins-base {{ gst_plugins_base }}
         # Temporary pin until the global gstreamer pin is updated.
         # OpenCV should be built against 1.28.1 specifically because this
         # release contains the CVE fixes we want to pick up.
+        - gst-plugins-base 1.28.1
         - gstreamer 1.28.1
         - libavif {{ libavif }}
         # harfbuzz, glib, gettext are both needed for freetype support

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,9 +91,6 @@ outputs:
         # which is not reflected in cbc.yaml yet
         - ffmpeg {{ ffmpeg }}
         - freetype {{ freetype }}
-        # Temporary pin until the global gstreamer pin is updated.
-        # OpenCV should be built against 1.28.1 specifically because this
-        # release contains the CVE fixes we want to pick up.
         - gst-plugins-base {{ gst_plugins_base }}
         - gstreamer {{ gstreamer }}
         - libavif {{ libavif }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.13.0" %}
 # give higher priority to the qt variant
-{% set build_num = 2 %}
+{% set build_num = 3 %}
 {% if build_variant == "normal" %}
 {% set build_num = 100 + build_num %}
 {% endif %}
@@ -92,7 +92,10 @@ outputs:
         - ffmpeg {{ ffmpeg }}
         - freetype {{ freetype }}
         - gst-plugins-base {{ gst_plugins_base }}
-        - gstreamer {{ gstreamer }}
+        # Temporary pin until the global gstreamer pin is updated.
+        # OpenCV should be built against 1.28.1 specifically because this
+        # release contains the CVE fixes we want to pick up.
+        - gstreamer 1.28.1
         - libavif {{ libavif }}
         # harfbuzz, glib, gettext are both needed for freetype support
         - harfbuzz {{ harfbuzz }}


### PR DESCRIPTION
rebuild

**Destination channel:** {defaults}

### Links

https://anaconda.atlassian.net/browse/PKG-13280

### Explanation of changes:

- rebuild gstreamer against 1.28.1 to pick up the CVE fixes
