### PR TITLE
opencv 4.13.0 rebuild against gstreamer 1.28.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,11 +15,3 @@ libabseil:
 libprotobuf:
   - 6.33.0
 
-# Temporary pin until the global gstreamer pin is updated.
-# OpenCV should be built against 1.28.1 specifically because this
-# release contains the CVE fixes we want to pick up.q
-gst_plugins_base:
-  - '1.28.1'
-
-gstreamer:
-  - '1.28.1'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,4 +10,16 @@ build_variant:
   - normal
   - headless
 
+libabseil:
+  - 20250814.1
+libprotobuf:
+  - 6.33.0
 
+# Temporary pin until the global gstreamer pin is updated.
+# OpenCV should be built against 1.28.1 specifically because this
+# release contains the CVE fixes we want to pick up.q
+gst_plugins_base:
+  - '1.28.1'
+
+gstreamer:
+  - '1.28.1'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@
 # much easier, at the expense of a few MBs in the 'lib' package.
 {% set version = "4.13.0" %}
 # give higher priority to the qt variant
-{% set build_num = 3 %}
+{% set build_num = 4 %}
 {% if build_variant == "normal" %}
 {% set build_num = 100 + build_num %}
 {% endif %}


### PR DESCRIPTION
opencv 4.13.0 rebuild against gstreamer 1.28.1 (build #4)

**Destination channel:** defaults

### Links

- [PKG-13280](https://anaconda.atlassian.net/browse/PKG-13280)
- Relevant dependency PRs:
  - similar changes, but different build number and built against the latest libabseil: https://github.com/AnacondaRecipes/opencv-feedstock/pull/46

### Explanation of changes:

- rebuild gstreamer against 1.28.1 to pick up the CVE fixes
- built against slightly older libabseil for upcoming vllm builds
- **If this build is used, it needs to either be merged before PR #46 or it needs to be merged to a versioned main**


[PKG-13280]: https://anaconda.atlassian.net/browse/PKG-13280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ