### PR TITLE
Replace open_mutex with libgomp

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@
 {% set version = "4.13.0" %}
 # give higher priority to the qt variant
 
-{% set build_num = 6 %}
+{% set build_num = 7 %}
 
 {% if build_variant == "normal" %}
 {% set build_num = 100 + build_num %}
@@ -116,8 +116,9 @@ outputs:
         - qt5compat {{ qt }}       # [build_variant == "normal"]
         - libgl-devel {{ libgl }}  # [linux]
         - libzlib {{ libzlib }}
+        - libgomp # [linux]
       run:
-        - _openmp_mutex         # [linux]
+        - libgomp # [linux]
         - python
         - numpy
         # bounds set through run exports


### PR DESCRIPTION
opencv openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14740](https://anaconda.atlassian.net/browse/PKG-14740) 

### Explanation of changes:

- Bump build number
- Replace _openmp_mutex with libgomp

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)


[PKG-14740]: https://anaconda.atlassian.net/browse/PKG-14740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ