### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@
 {% set version = "4.13.0" %}
 # give higher priority to the qt variant
 
-{% set build_num = 7 %}
+{% set build_num = 8 %}
 
 {% if build_variant == "normal" %}
 {% set build_num = 100 + build_num %}
@@ -99,7 +99,7 @@ outputs:
         # harfbuzz, glib, gettext are both needed for freetype support
         - harfbuzz {{ harfbuzz }}
         - hdf5 {{ hdf5 }}
-        - jpeg {{ jpeg }}
+        - libjpeg-turbo {{ libjpeg_turbo }}
         - libabseil {{ libabseil }}
         - glib {{ glib }}
         # libglib is needed to satisfy the linter
@@ -129,7 +129,7 @@ outputs:
         - gst-plugins-base
         - gstreamer
         - hdf5
-        - jpeg            # [not win]
+        - libjpeg-turbo   # [not win]
         - libopenjpeg
         - libiconv        # [unix]
         - libpng


### PR DESCRIPTION
opencv 4.13.0

**Destination channel:** defaults

### Links

- [PKG-13231](https://anaconda.atlassian.net/browse/PKG-13231) 
- [Upstream repository](https://github.com/opencv/opencv/tree/5.0.0)

### Explanation of changes:
- New build number
- Replace  jpeg to libjpeg-turbo


[PKG-13231]: https://anaconda.atlassian.net/browse/PKG-13231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ